### PR TITLE
Fix undeploy path

### DIFF
--- a/controllers/clusterhealthcheck_deployer.go
+++ b/controllers/clusterhealthcheck_deployer.go
@@ -143,10 +143,9 @@ func (r *ClusterHealthCheckReconciler) undeployClusterHealthCheck(ctx context.Co
 
 	var err error
 	for i := range chc.Status.ClusterConditions {
-		var shardMatch bool
-		shardMatch, err = r.isClusterAShardMatch(ctx, &chc.Status.ClusterConditions[i].ClusterInfo)
-		if err != nil {
-			return err
+		shardMatch, tmpErr := r.isClusterAShardMatch(ctx, &chc.Status.ClusterConditions[i].ClusterInfo)
+		if tmpErr != nil {
+			err = tmpErr
 		}
 
 		if !shardMatch && chc.Status.ClusterConditions[i].ClusterInfo.Status != libsveltosv1alpha1.SveltosStatusRemoved {
@@ -157,7 +156,7 @@ func (r *ClusterHealthCheckReconciler) undeployClusterHealthCheck(ctx context.Co
 
 		c := &chc.Status.ClusterConditions[i].ClusterInfo.Cluster
 
-		_, tmpErr := r.removeClusterHealthCheck(ctx, chcScope, c, f, logger)
+		_, tmpErr = r.removeClusterHealthCheck(ctx, chcScope, c, f, logger)
 		if tmpErr != nil {
 			err = tmpErr
 		}


### PR DESCRIPTION
When using cluster sharding, when reconciling ClusterHealthCheck delete path, 
if a cluster is not a shard match, treat it as an error. 
This will make sure finalizer is not removed hence giving a chance to the deployment
matching the shard to clean up.