### PR TITLE
Fix an error with multiple cluster shards

### DIFF
--- a/controllers/clusterhealthcheck_controller.go
+++ b/controllers/clusterhealthcheck_controller.go
@@ -182,6 +182,7 @@ func (r *ClusterHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// changes.
 	defer func() {
 		if err := clusterHealthCheckScope.Close(ctx); err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to update: %v", err))
 			reterr = err
 		}
 	}()


### PR DESCRIPTION
ClusterInfo Hash is a required parameter. For a given cluster matching an ClusterHealthCheck this is set by the Sveltos deployment matching the cluster shard.

Other deployment will simply skip such ClusterInfo. Since this is a required field, if deployment matching the shard it has not processed the ClusterHealthCheck instance, any other Sveltos deployment will set it to empty if not set already.