### PR TITLE
Add Teams notification integration

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -86,6 +86,7 @@ var (
 func GetWebexRoom(info *webexInfo) string {
 	return info.room
 }
+
 func GetWebexToken(info *webexInfo) string {
 	return info.token
 }
@@ -93,6 +94,11 @@ func GetWebexToken(info *webexInfo) string {
 func GetSlackChannelID(info *slackInfo) string {
 	return info.channelID
 }
+
 func GetSlackToken(info *slackInfo) string {
 	return info.token
+}
+
+func GetTeamsWebhookUrl(info *teamsInfo) string {
+	return info.webhookUrl
 }

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -86,7 +86,6 @@ var (
 func GetWebexRoom(info *webexInfo) string {
 	return info.room
 }
-
 func GetWebexToken(info *webexInfo) string {
 	return info.token
 }
@@ -94,11 +93,6 @@ func GetWebexToken(info *webexInfo) string {
 func GetSlackChannelID(info *slackInfo) string {
 	return info.channelID
 }
-
 func GetSlackToken(info *slackInfo) string {
 	return info.token
-}
-
-func GetTeamsWebhookUrl(info *teamsInfo) string {
-	return info.webhookUrl
 }

--- a/controllers/notification.go
+++ b/controllers/notification.go
@@ -220,7 +220,7 @@ func sendTeamsNotification(ctx context.Context, c client.Client, clusterNamespac
 	teamsClient := goteamsnotify.NewTeamsClient()
 
 	// Validate Teams Webhook expected format
-	if err := teamsClient.ValidateWebhook(info.webhookUrl); err != nil {
+	if teamsClient.ValidateWebhook(info.webhookUrl) != nil {
 		l.V(logs.LogInfo).Info("failed to validate Teams webhook URL: %v", err)
 		return err
 	}
@@ -233,7 +233,7 @@ func sendTeamsNotification(ctx context.Context, c client.Client, clusterNamespac
 	}
 
 	// Send the meesage with the user provided webhook URL
-	if err := teamsClient.Send(info.webhookUrl, teamsMessage); err != nil {
+	if teamsClient.Send(info.webhookUrl, teamsMessage) != nil {
 		l.V(logs.LogInfo).Info("failed to send Teams message: %v", err)
 		return err
 	}

--- a/controllers/notification.go
+++ b/controllers/notification.go
@@ -237,6 +237,7 @@ func sendTeamsNotification(ctx context.Context, c client.Client, clusterNamespac
 		l.V(logs.LogInfo).Info("failed to send Teams message: %v", err)
 		return err
 	}
+
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v0.24.0
-	github.com/projectsveltos/libsveltos v0.24.0
+	github.com/projectsveltos/libsveltos v0.24.1-0.20240221165142-94ea5e6f7fa7
 	github.com/prometheus/client_golang v1.18.0
 	github.com/slack-go/slack v0.12.3
 	github.com/spf13/pflag v1.0.5
@@ -39,6 +39,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/atc0005/go-teams-notify/v2 v2.10.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/atc0005/go-teams-notify/v2 v2.10.0 h1:eQvRIkyESQgBvlUdQ/iPol/lj3QcRyrdEQM3+c/nXhM=
+github.com/atc0005/go-teams-notify/v2 v2.10.0/go.mod h1:SIeE1UfCcVRYMqP5b+r1ZteHyA/2UAjzWF5COnZ8q0w=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -347,6 +349,8 @@ github.com/projectsveltos/addon-controller v0.24.0 h1:Cj1Nj46DOM58UVpRiJlvsxpQVZ
 github.com/projectsveltos/addon-controller v0.24.0/go.mod h1:undt3E66BCg13mnAYUouLXCJlNwNgG5V1xbljjV2BZs=
 github.com/projectsveltos/libsveltos v0.24.0 h1:2wxUqLhIEJMRye9rHypc+uT0M++CunByuOA5Pu6TGH8=
 github.com/projectsveltos/libsveltos v0.24.0/go.mod h1:h2NUzyHkIc9u6T4NOQzpPnJmX8Rrumpmszo8wM8BUkA=
+github.com/projectsveltos/libsveltos v0.24.1-0.20240221165142-94ea5e6f7fa7 h1:7QxEtVOtugOAst7ZWETEL/Fm4nOYyVhrXiBhxqDnqbA=
+github.com/projectsveltos/libsveltos v0.24.1-0.20240221165142-94ea5e6f7fa7/go.mod h1:h2NUzyHkIc9u6T4NOQzpPnJmX8Rrumpmszo8wM8BUkA=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=


### PR DESCRIPTION
Adds the ability to send out simple Microsoft Teams notifications with ClusterHealthChecks using the [goteamsnotify](https://pkg.go.dev/github.com/atc0005/go-teams-notify/v2) package.