### PR TITLE
Complete unqualified image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ deploy-projectsveltos: $(KUSTOMIZE) $(KUBECTL)
 
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
 
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resource)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/healthcheck-manager:main
+      - image: docker.io/projectsveltos/healthcheck-manager:main
         name: manager

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -223,7 +223,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows applications to run on CRIs not configured to handle unqualified registries.