### PR TITLE
(feat) CAPI clusters

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -13,5 +13,6 @@ spec:
         args:
         - "--diagnostics-address=:8443"
         - "--shard-key="
+        - "--capi-onboard-annotation="
         - "--v=5"
         - "--version=main"

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -36,6 +36,7 @@ type HealthCheckReconciler struct {
 	Scheme                *runtime.Scheme
 	HealthCheckReportMode ReportMode
 	ShardKey              string // when set, only clusters matching the ShardKey will be reconciled
+	CapiOnboardAnnotation string // when set, only capi clusters with this annotation are considered
 	Version               string
 }
 
@@ -79,7 +80,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager.
 func (r *HealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.HealthCheckReportMode == CollectFromManagementCluster {
-		go collectHealthCheckReports(mgr.GetClient(), r.ShardKey, r.Version, mgr.GetLogger())
+		go collectHealthCheckReports(mgr.GetClient(), r.ShardKey, r.CapiOnboardAnnotation, r.Version, mgr.GetLogger())
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/healthcheckreport_collection.go
+++ b/controllers/healthcheckreport_collection.go
@@ -98,7 +98,7 @@ func removeHealthCheckReportsFromCluster(ctx context.Context, c client.Client, c
 }
 
 // Periodically collects HealthCheckReports from each managed cluster.
-func collectHealthCheckReports(c client.Client, shardKey, version string, logger logr.Logger) {
+func collectHealthCheckReports(c client.Client, shardKey, capiOnboardAnnotation, version string, logger logr.Logger) {
 	interval := 10 * time.Second
 	if shardKey != "" {
 		// This controller will only fetch ClassifierReport instances
@@ -109,7 +109,7 @@ func collectHealthCheckReports(c client.Client, shardKey, version string, logger
 	ctx := context.TODO()
 	for {
 		logger.V(logs.LogDebug).Info("collecting HealthCheckReports")
-		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", shardKey, logger)
+		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", capiOnboardAnnotation, shardKey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clusters: %v", err))
 		}

--- a/controllers/reloaderreport_collection.go
+++ b/controllers/reloaderreport_collection.go
@@ -35,13 +35,15 @@ import (
 )
 
 // Periodically collects ReloaderReports from each managed cluster.
-func collectReloaderReports(c client.Client, collectionInterval int, shardKey, version string, logger logr.Logger) {
+func collectReloaderReports(c client.Client, collectionInterval int, shardKey, capiOnboardAnnotation, version string,
+	logger logr.Logger) {
+
 	logger.V(logs.LogInfo).Info(fmt.Sprintf("collection time is set to %d seconds", collectionInterval))
 
 	ctx := context.TODO()
 	for {
 		logger.V(logs.LogDebug).Info("collecting ReloaderReports")
-		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", shardKey, logger)
+		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", capiOnboardAnnotation, shardKey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clusters: %v", err))
 		}

--- a/controllers/reloaderreport_controller.go
+++ b/controllers/reloaderreport_controller.go
@@ -44,10 +44,11 @@ const (
 // ReloaderReportReconciler reconciles a ReloaderReport object
 type ReloaderReportReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
-	ReloaderReportMode ReportMode
-	ShardKey           string // when set, only clusters matching the ShardKey will be reconciled
-	Version            string
+	Scheme                *runtime.Scheme
+	ReloaderReportMode    ReportMode
+	ShardKey              string // when set, only clusters matching the ShardKey will be reconciled
+	CapiOnboardAnnotation string // when set, only capi clusters with this annotation are considered
+	Version               string
 }
 
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=reloaderreports,verbs=create;get;list;watch;update;patch;delete
@@ -92,7 +93,8 @@ func (r *ReloaderReportReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReloaderReportReconciler) SetupWithManager(mgr ctrl.Manager, collectionInterval int) error {
 	if r.ReloaderReportMode == CollectFromManagementCluster {
-		go collectReloaderReports(mgr.GetClient(), collectionInterval, r.ShardKey, r.Version, mgr.GetLogger())
+		go collectReloaderReports(mgr.GetClient(), collectionInterval, r.ShardKey, r.CapiOnboardAnnotation,
+			r.Version, mgr.GetLogger())
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v0.48.1
-	github.com/projectsveltos/libsveltos v0.48.1
+	github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f
 	github.com/prometheus/client_golang v1.20.5
 	github.com/slack-go/slack v0.16.0
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectsveltos/addon-controller v0.48.1 h1:DN41/UJes8uYfWKkDNli8uqeMA2KmPCpsQu+qix9sPU=
 github.com/projectsveltos/addon-controller v0.48.1/go.mod h1:/DAODslGfcANpHiwgeoptZ71wVoSMwakOMw7jrlHB+o=
-github.com/projectsveltos/libsveltos v0.48.1 h1:SWtACXeVNehWNxh/jEeFB/Z1QqMd4HeSh5Z60czwJbQ=
-github.com/projectsveltos/libsveltos v0.48.1/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f h1:QyRB2GW8b2D4d9a5fT8spSSW5NzDzOdz/cQsg7toehs=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
 github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -21,6 +21,7 @@ spec:
       - args:
         - --diagnostics-address=:8443
         - --shard-key={{.SHARD}}
+        - --capi-onboard-annotation=
         - --v=5
         - --version=main
         command:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -167,6 +167,7 @@ spec:
       - args:
         - --diagnostics-address=:8443
         - --shard-key=
+        - --capi-onboard-annotation=
         - --v=5
         - --version=main
         command:


### PR DESCRIPTION
healthcheck-manager can be passed a new arg: `capi-onboard-annotation`. It allows administrators to specify a custom annotation key. When this annotation is set, Sveltos will only manage CAPI clusters that have this specific annotation with any value.

CAPI clusters without this annotation will be ignored by Sveltos.