### PR TITLE
(bug) Remove HealthCheckReport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.0
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,5 +15,5 @@ spec:
         - "--shard-key="
         - "--capi-onboard-annotation="
         - "--v=5"
-        - "--version=v1.0.0"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/healthcheck-manager:v1.0.0
+      - image: docker.io/projectsveltos/healthcheck-manager:main
         name: manager

--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -51,7 +51,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	healthCheck := &libsveltosv1beta1.HealthCheck{}
 	if err := r.Get(ctx, req.NamespacedName, healthCheck); err != nil {
 		if apierrors.IsNotFound(err) {
-			err = removeHealthCheckReports(ctx, r.Client, healthCheck, logger)
+			err = removeHealthCheckReports(ctx, r.Client, req.Name, logger)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -67,7 +67,7 @@ func (r *HealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Handle deleted healthCheck
 	if !healthCheck.DeletionTimestamp.IsZero() {
-		err := removeHealthCheckReports(ctx, r.Client, healthCheck, logger)
+		err := removeHealthCheckReports(ctx, r.Client, healthCheck.Name, logger)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/controllers/healthcheckreport_collection.go
+++ b/controllers/healthcheckreport_collection.go
@@ -41,12 +41,12 @@ const (
 )
 
 // removeHealthCheckReports deletes all HealthCheckReport corresponding to HealthCheck instance
-func removeHealthCheckReports(ctx context.Context, c client.Client, healthCheck *libsveltosv1beta1.HealthCheck,
+func removeHealthCheckReports(ctx context.Context, c client.Client, healthCheckName string,
 	logger logr.Logger) error {
 
 	listOptions := []client.ListOption{
 		client.MatchingLabels{
-			libsveltosv1beta1.HealthCheckNameLabel: healthCheck.Name,
+			libsveltosv1beta1.HealthCheckNameLabel: healthCheckName,
 		},
 	}
 

--- a/controllers/healthcheckreport_collection_test.go
+++ b/controllers/healthcheckreport_collection_test.go
@@ -56,7 +56,7 @@ var _ = Describe("HealthCheck Deployer", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
 			WithObjects(initObjects...).Build()
 
-		Expect(controllers.RemoveHealthCheckReports(context.TODO(), c, healthCheck, logger)).To(Succeed())
+		Expect(controllers.RemoveHealthCheckReports(context.TODO(), c, healthCheck.Name, logger)).To(Succeed())
 
 		healthCheckReportList := &libsveltosv1beta1.HealthCheckReportList{}
 		Expect(c.List(context.TODO(), healthCheckReportList)).To(Succeed())

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,11 +23,11 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/healthcheck-manager:v1.0.0
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -192,11 +192,11 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/healthcheck-manager:v1.0.0
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/sveltos-agent.yaml
+++ b/test/sveltos-agent.yaml
@@ -175,12 +175,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:v1.0.0
+        image: docker.io/projectsveltos/sveltos-agent:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When HealthCheck is deleted, HealthCheckReport must be deleted. HealthCheck does not have a finalizer, so by the time the reconciliation was happening for an HealthCheck instance, this was not present anymore leading to stale HealthCheckReports.

This PR fixes that by using the ctrl.Request Name instead.

Fixes #332 