### PR TITLE
(opt) Optmize HealthCheckReport collection

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,8 +68,10 @@ rules:
 - apiGroups:
   - config.projectsveltos.io
   resources:
+  - clusterprofiles
   - clustersummaries
   - clustersummaries/status
+  - profiles
   verbs:
   - get
   - list

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -67,10 +67,14 @@ var (
 	RemoveHealthCheckReports                       = removeHealthCheckReports
 	RemoveHealthCheckReportsFromCluster            = removeHealthCheckReportsFromCluster
 	CollectAndProcessHealthCheckReportsFromCluster = collectAndProcessHealthCheckReportsFromCluster
+	CollectAndProcessAllHealthCheckReports         = collectAndProcessAllHealthCheckReports
+	BuildClustersWithHealthCheck                   = buildClustersWithHealthCheck
 )
 
 var (
 	CollectAndProcessReloaderReportsFromCluster = collectAndProcessReloaderReportsFromCluster
+	CollectAndProcessAllReloaderReports         = collectAndProcessAllReloaderReports
+	BuildClustersWithReloader                   = buildClustersWithReloader
 )
 
 var (

--- a/controllers/healthcheckreport_collection.go
+++ b/controllers/healthcheckreport_collection.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -38,7 +39,86 @@ import (
 const (
 	malformedLabelError = "healthCheckReport is malformed. Labels is empty"
 	missingLabelError   = "healthCheckReport is malformed. Label missing"
+
+	// clustersPerWorker controls how many clusters each worker goroutine handles.
+	clustersPerWorker = 50
+	// maxCollectionWorkers caps the number of concurrent goroutines collecting HealthCheckReports.
+	maxCollectionWorkers = 5
 )
+
+// clusterKey uniquely identifies a cluster by namespace, name, and type so that a
+// SveltosCluster and a CAPI Cluster sharing the same namespace and name are treated separately.
+type clusterKey struct{ ns, name, clusterType string }
+
+// buildShardClustersMap returns a lookup of shard-local clusters keyed by clusterKey.
+func buildShardClustersMap(clusterList []corev1.ObjectReference) map[clusterKey]corev1.ObjectReference {
+	m := make(map[clusterKey]corev1.ObjectReference, len(clusterList))
+	for i := range clusterList {
+		ref := clusterList[i]
+		ct := strings.ToLower(string(clusterproxy.GetClusterType(&ref)))
+		m[clusterKey{ref.Namespace, ref.Name, ct}] = ref
+	}
+	return m
+}
+
+// findClusterForReport extracts the cluster key from a report's labels and checks whether
+// that cluster is in shardClusters. Returns (key, ref, true) on a match.
+func findClusterForReport(ns string, labels map[string]string,
+	clusterNameLabel, clusterTypeLabel string,
+	shardClusters map[clusterKey]corev1.ObjectReference,
+) (clusterKey, corev1.ObjectReference, bool) {
+
+	if labels == nil {
+		return clusterKey{}, corev1.ObjectReference{}, false
+	}
+	clusterName := labels[clusterNameLabel]
+	clusterType := labels[clusterTypeLabel]
+	if clusterName == "" || clusterType == "" {
+		return clusterKey{}, corev1.ObjectReference{}, false
+	}
+	key := clusterKey{ns, clusterName, clusterType}
+	ref, ok := shardClusters[key]
+	return key, ref, ok
+}
+
+// clusterReportGroup holds a cluster reference and all report items belonging to it.
+type clusterReportGroup[T any] struct {
+	ref   corev1.ObjectReference
+	items []*T
+}
+
+// groupReportsByCluster groups report items by the cluster identified via clusterNameLabel and
+// clusterTypeLabel, filtering to only shard-local clusters.
+func groupReportsByCluster[T any](
+	reports []T,
+	getLabels func(*T) map[string]string,
+	getNamespace func(*T) string,
+	clusterNameLabel, clusterTypeLabel string,
+	shardClusters map[clusterKey]corev1.ObjectReference,
+) []*clusterReportGroup[T] {
+
+	byCluster := make(map[clusterKey]*clusterReportGroup[T])
+	for i := range reports {
+		item := &reports[i]
+		key, ref, ok := findClusterForReport(getNamespace(item), getLabels(item),
+			clusterNameLabel, clusterTypeLabel, shardClusters)
+		if !ok {
+			continue
+		}
+		cd, exists := byCluster[key]
+		if !exists {
+			cd = &clusterReportGroup[T]{ref: ref}
+			byCluster[key] = cd
+		}
+		cd.items = append(cd.items, item)
+	}
+
+	groups := make([]*clusterReportGroup[T], 0, len(byCluster))
+	for _, cd := range byCluster {
+		groups = append(groups, cd)
+	}
+	return groups
+}
 
 // removeHealthCheckReports deletes all HealthCheckReport corresponding to HealthCheck instance
 func removeHealthCheckReports(ctx context.Context, c client.Client, healthCheckName string,
@@ -97,6 +177,203 @@ func removeHealthCheckReportsFromCluster(ctx context.Context, c client.Client, c
 	return nil
 }
 
+// buildClustersWithHealthCheck returns the set of all clusters currently matched
+// by at least one ClusterHealthCheck, derived from ClusterHealthCheck.Status.MatchingClusterRefs.
+// This is used to skip clusters that have no ClusterHealthChecks and therefore no
+// HealthCheckReports to collect.
+func buildClustersWithHealthCheck(clusterHealthChecks *libsveltosv1beta1.ClusterHealthCheckList) map[corev1.ObjectReference]bool {
+	clusters := make(map[corev1.ObjectReference]bool)
+	for i := range clusterHealthChecks.Items {
+		for j := range clusterHealthChecks.Items[i].Status.MatchingClusterRefs {
+			clusters[clusterHealthChecks.Items[i].Status.MatchingClusterRefs[j]] = true
+		}
+	}
+	return clusters
+}
+
+// collectHealthCheckReportFromCluster delegates per-cluster collection to
+// collectAndProcessHealthCheckReportsFromCluster with a cluster-tagged logger.
+func collectHealthCheckReportFromCluster(ctx context.Context, c client.Client,
+	cluster *corev1.ObjectReference, version string, logger logr.Logger) error {
+
+	l := logger.WithValues("cluster", fmt.Sprintf("%s %s/%s", cluster.Kind, cluster.Namespace, cluster.Name))
+	return collectAndProcessHealthCheckReportsFromCluster(ctx, c, cluster, version, l)
+}
+
+// processHealthCheckReportClusters collects and processes HealthCheckReports for the given clusters.
+// It runs sequentially when there are fewer than clustersPerWorker clusters, and spawns
+// up to maxCollectionWorkers goroutines otherwise.
+func processHealthCheckReportClusters(ctx context.Context, c client.Client,
+	clusters []corev1.ObjectReference, version string, logger logr.Logger) error {
+
+	logErr := func(cluster *corev1.ObjectReference, err error) {
+		logger.WithValues("cluster", fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)).
+			V(logs.LogInfo).Info(fmt.Sprintf("failed to collect HealthCheckReports: %v", err))
+	}
+
+	numWorkers := len(clusters) / clustersPerWorker
+	if numWorkers > maxCollectionWorkers {
+		numWorkers = maxCollectionWorkers
+	}
+
+	if numWorkers == 0 {
+		// Sequential: fewer than clustersPerWorker clusters, goroutine overhead not justified.
+		var retErr error
+		for i := range clusters {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			cluster := &clusters[i]
+			if err := collectHealthCheckReportFromCluster(ctx, c, cluster, version, logger); err != nil {
+				logErr(cluster, err)
+				retErr = err
+			}
+		}
+		return retErr
+	}
+
+	// Parallel: one worker per clustersPerWorker clusters, capped at maxCollectionWorkers.
+	work := make(chan corev1.ObjectReference, len(clusters))
+	for _, cluster := range clusters {
+		work <- cluster
+	}
+	close(work)
+
+	var (
+		mu     sync.Mutex
+		retErr error
+		wg     sync.WaitGroup
+	)
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for clusterRef := range work {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				ref := clusterRef
+				if err := collectHealthCheckReportFromCluster(ctx, c, &ref, version, logger); err != nil {
+					logErr(&ref, err)
+					mu.Lock()
+					retErr = err
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return retErr
+	}
+}
+
+// collectAndProcessAllHealthCheckReports is used in agentless mode. It fetches all
+// HealthCheckReports from the management cluster in a single List call, groups them by
+// cluster, and processes only clusters that have reports — avoiding N per-cluster List calls.
+func collectAndProcessAllHealthCheckReports(ctx context.Context, c client.Client,
+	clusterList []corev1.ObjectReference, version string, logger logr.Logger) error {
+
+	shardClusters := buildShardClustersMap(clusterList)
+
+	hcrList := &libsveltosv1beta1.HealthCheckReportList{}
+	if err := c.List(ctx, hcrList); err != nil {
+		return err
+	}
+
+	getLabels := func(h *libsveltosv1beta1.HealthCheckReport) map[string]string { return h.Labels }
+	getNamespace := func(h *libsveltosv1beta1.HealthCheckReport) string { return h.Namespace }
+	byCluster := groupReportsByCluster(hcrList.Items,
+		getLabels, getNamespace,
+		libsveltosv1beta1.HealthCheckReportClusterNameLabel,
+		libsveltosv1beta1.HealthCheckReportClusterTypeLabel,
+		shardClusters)
+
+	var retErr error
+	for _, cd := range byCluster {
+		l := logger.WithValues("cluster", fmt.Sprintf("%s %s/%s", cd.ref.Kind, cd.ref.Namespace, cd.ref.Name))
+		if err := processHealthCheckReportsForClusterInAgentlessMode(ctx, c, &cd.ref, cd.items, version, l); err != nil {
+			retErr = err
+		}
+	}
+
+	return retErr
+}
+
+// processHealthCheckReportsForClusterInAgentlessMode handles all HealthCheckReports for a single
+// cluster in agentless mode. It checks readiness, version compatibility, and processes each report.
+func processHealthCheckReportsForClusterInAgentlessMode(ctx context.Context, c client.Client,
+	ref *corev1.ObjectReference, hcrs []*libsveltosv1beta1.HealthCheckReport,
+	version string, logger logr.Logger) error {
+
+	clusterRef := &corev1.ObjectReference{
+		Namespace:  ref.Namespace,
+		Name:       ref.Name,
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+	}
+	ready, err := clusterproxy.IsClusterReadyToBeConfigured(ctx, c, clusterRef, logger)
+	if err != nil {
+		logger.V(logs.LogDebug).Info("cluster is not ready yet")
+		return err
+	}
+	if !ready {
+		return nil
+	}
+
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, c, version, ref.Namespace, ref.Name,
+		clusterproxy.GetClusterType(ref), true, logger) {
+
+		logger.V(logs.LogDebug).Info(compatibilityErrorMsg)
+		return errors.New(compatibilityErrorMsg)
+	}
+
+	var retErr error
+	for _, hcr := range hcrs {
+		var mgmtHealthCheckReport *libsveltosv1beta1.HealthCheckReport
+		if !hcr.DeletionTimestamp.IsZero() {
+			logger.V(logs.LogDebug).Info("deleting from management cluster")
+			if err := deleteHealthCheckReport(ctx, c, ref, hcr, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to delete HealthCheckReport in management cluster")
+				retErr = err
+				continue
+			}
+		} else {
+			logger.V(logs.LogDebug).Info("updating in management cluster")
+			mgmtHealthCheckReport, err = updateHealthCheckReport(ctx, c, ref, hcr, logger)
+			if err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to update HealthCheckReport in management cluster")
+				retErr = err
+				continue
+			}
+		}
+
+		// In agentless mode, the Status of HealthCheckReport in the management cluster will be updated.
+		// So set hcr to current version (update otherwise will fail with object has been modified).
+		if mgmtHealthCheckReport != nil {
+			hcr = mgmtHealthCheckReport
+		}
+
+		logger.V(logs.LogDebug).Info("updating HealthCheckReport status")
+		phase := libsveltosv1beta1.ReportProcessed
+		hcr.Status.Phase = &phase
+		if err := c.Status().Update(ctx, hcr); err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to update HealthCheckReport status in management cluster")
+			retErr = err
+		}
+	}
+
+	return retErr
+}
+
 // Periodically collects HealthCheckReports from each managed cluster.
 func collectHealthCheckReports(c client.Client, shardKey, capiOnboardAnnotation, version string, logger logr.Logger) {
 	interval := 10 * time.Second
@@ -109,17 +386,43 @@ func collectHealthCheckReports(c client.Client, shardKey, capiOnboardAnnotation,
 	ctx := context.TODO()
 	for {
 		logger.V(logs.LogDebug).Info("collecting HealthCheckReports")
+
+		clusterHealthChecks := &libsveltosv1beta1.ClusterHealthCheckList{}
+		if err := c.List(ctx, clusterHealthChecks); err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to list ClusterHealthChecks")
+			time.Sleep(interval)
+			continue
+		}
+
 		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", capiOnboardAnnotation, shardKey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to get clusters")
+			time.Sleep(interval)
+			continue
 		}
 
+		// Restrict collection to clusters actually matched by a ClusterHealthCheck.
+		// Clusters with no matching ClusterHealthCheck have no HealthCheckReports to collect,
+		// so we avoid all per-cluster API calls for them. clustersWithHC is built from
+		// ClusterHealthCheck.Status.MatchingClusterRefs without shard awareness, so we
+		// intersect with the shard-local clusterList.
+		clustersWithHC := buildClustersWithHealthCheck(clusterHealthChecks)
+		var clustersToCollect []corev1.ObjectReference
 		for i := range clusterList {
-			cluster := &clusterList[i]
-			l := logger.WithValues("cluster", fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name))
-			err = collectAndProcessHealthCheckReportsFromCluster(ctx, c, cluster, version, l)
-			if err != nil {
-				l.V(logs.LogInfo).Error(err, "failed to collect HealthCheckReports")
+			if clustersWithHC[clusterList[i]] {
+				clustersToCollect = append(clustersToCollect, clusterList[i])
+			}
+		}
+
+		// In agentless mode all HealthCheckReports live in the management cluster.
+		// A single List call covers every cluster, avoiding N per-cluster API calls.
+		if getAgentInMgmtCluster() {
+			if err := collectAndProcessAllHealthCheckReports(ctx, c, clustersToCollect, version, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to collect HealthCheckReports")
+			}
+		} else {
+			if err := processHealthCheckReportClusters(ctx, c, clustersToCollect, version, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to collect HealthCheckReports")
 			}
 		}
 

--- a/controllers/healthcheckreport_collection_test.go
+++ b/controllers/healthcheckreport_collection_test.go
@@ -18,6 +18,8 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -36,13 +38,48 @@ import (
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
+const (
+	cmVersionName = "sveltos-agent-version"
+)
+
 var _ = Describe("HealthCheck Deployer", func() {
 	var healthCheck *libsveltosv1beta1.HealthCheck
 	var logger logr.Logger
+	var version string
 
 	BeforeEach(func() {
+		version = randomString()
 		healthCheck = getHealthCheckInstance(randomString())
 		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+
+		By("Create the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controllers.ReportNamespace,
+				Name:      cmVersionName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Delete the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{}
+		Expect(testEnv.Get(context.TODO(),
+			types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+			cm)).To(Succeed())
+		Expect(testEnv.Delete(context.TODO(), cm)).To(Succeed())
+
+		Eventually(func() bool {
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+				cm)
+			return err != nil && apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
 	})
 
 	It("removeHealthCheckReports deletes all HealthCheckReport for a given HealthCheck instance", func() {
@@ -136,6 +173,176 @@ var _ = Describe("HealthCheck Deployer", func() {
 			testEnv.Client, getClusterRef(cluster), version, logger)).To(Succeed())
 
 		validateHealthCheckReports(healthCheckName, cluster, &clusterType)
+	})
+})
+
+var _ = Describe("HealthCheckReport Collection", func() {
+	version := randomString()
+
+	BeforeEach(func() {
+		version = randomString()
+
+		By("Create the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controllers.ReportNamespace,
+				Name:      cmVersionName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Delete the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{}
+		Expect(testEnv.Get(context.TODO(),
+			types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+			cm)).To(Succeed())
+		Expect(testEnv.Delete(context.TODO(), cm)).To(Succeed())
+
+		Eventually(func() bool {
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+				cm)
+			return err != nil && apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+	})
+
+	It("buildClustersWithHealthCheck returns all clusters matched by any ClusterHealthCheck", func() {
+		cluster1 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+		cluster2 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+		cluster3 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "SveltosCluster"}
+		cluster4 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+
+		chc1 := libsveltosv1beta1.ClusterHealthCheck{
+			ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+		}
+		chc1.Status.MatchingClusterRefs = []corev1.ObjectReference{cluster1, cluster2}
+
+		chc2 := libsveltosv1beta1.ClusterHealthCheck{
+			ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+		}
+		chc2.Status.MatchingClusterRefs = []corev1.ObjectReference{cluster2, cluster3}
+
+		// cluster4 is not referenced by any ClusterHealthCheck
+
+		clusterHealthChecks := &libsveltosv1beta1.ClusterHealthCheckList{
+			Items: []libsveltosv1beta1.ClusterHealthCheck{chc1, chc2},
+		}
+
+		result := controllers.BuildClustersWithHealthCheck(clusterHealthChecks)
+		Expect(result).To(HaveLen(3))
+		Expect(result[cluster1]).To(BeTrue())
+		Expect(result[cluster2]).To(BeTrue())
+		Expect(result[cluster3]).To(BeTrue())
+		Expect(result).NotTo(HaveKey(cluster4))
+	})
+
+	It("collectAndProcessAllHealthCheckReports distinguishes CAPI and Sveltos clusters with same namespace and name", func() {
+		capiCluster := prepareCluster()
+
+		cmName := fmt.Sprintf("sa-%s-%s", strings.ToLower(string(libsveltosv1beta1.ClusterTypeCapi)), capiCluster.Name)
+		cmNamespace := capiCluster.Namespace
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cmNamespace,
+				Name:      cmName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+
+		healthCheckName := randomString()
+		healthCheck := getHealthCheckInstance(healthCheckName)
+		Expect(testEnv.Create(context.TODO(), healthCheck)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, healthCheck)).To(Succeed())
+
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+		capiClusterType := strings.ToLower(string(clusterType))
+		sveltosClusterType := strings.ToLower(string(libsveltosv1beta1.ClusterTypeSveltos))
+
+		// capiHCR: belongs to the CAPI cluster — its Spec.ClusterName is set
+		// so updateHealthCheckReport returns early, and Phase is updated to Processed.
+		capiHCR := &libsveltosv1beta1.HealthCheckReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: capiCluster.Namespace,
+				Labels: map[string]string{
+					libsveltosv1beta1.HealthCheckNameLabel:              healthCheckName,
+					libsveltosv1beta1.HealthCheckReportClusterNameLabel: capiCluster.Name,
+					libsveltosv1beta1.HealthCheckReportClusterTypeLabel: capiClusterType,
+				},
+			},
+			Spec: libsveltosv1beta1.HealthCheckReportSpec{
+				HealthCheckName:  healthCheckName,
+				ClusterNamespace: capiCluster.Namespace,
+				ClusterName:      capiCluster.Name,
+				ClusterType:      clusterType,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), capiHCR)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, capiHCR)).To(Succeed())
+
+		// sveltosHCR: same namespace and cluster name as capiCluster but type=sveltos.
+		// It must NOT be processed since the sveltos cluster is not in clusterList.
+		sveltosHCR := &libsveltosv1beta1.HealthCheckReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: capiCluster.Namespace,
+				Labels: map[string]string{
+					libsveltosv1beta1.HealthCheckNameLabel:              healthCheckName,
+					libsveltosv1beta1.HealthCheckReportClusterNameLabel: capiCluster.Name,
+					libsveltosv1beta1.HealthCheckReportClusterTypeLabel: sveltosClusterType,
+				},
+			},
+			Spec: libsveltosv1beta1.HealthCheckReportSpec{
+				HealthCheckName:  healthCheckName,
+				ClusterNamespace: capiCluster.Namespace,
+				ClusterName:      capiCluster.Name,
+				ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), sveltosHCR)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, sveltosHCR)).To(Succeed())
+
+		capiClusterRef := corev1.ObjectReference{
+			Namespace:  capiCluster.Namespace,
+			Name:       capiCluster.Name,
+			Kind:       capiCluster.Kind,
+			APIVersion: capiCluster.APIVersion,
+		}
+
+		// Only the CAPI cluster is in the cluster list.
+		clusterList := []corev1.ObjectReference{capiClusterRef}
+		logger := textlogger.NewLogger(textlogger.NewConfig())
+
+		Expect(controllers.CollectAndProcessAllHealthCheckReports(context.TODO(), testEnv.Client,
+			clusterList, version, logger)).To(Succeed())
+
+		// capiHCR must eventually have Phase = ReportProcessed.
+		Eventually(func() bool {
+			current := &libsveltosv1beta1.HealthCheckReport{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: capiHCR.Namespace, Name: capiHCR.Name}, current)
+			return err == nil && current.Status.Phase != nil &&
+				*current.Status.Phase == libsveltosv1beta1.ReportProcessed
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		// sveltosHCR must consistently NOT be processed (Phase remains nil).
+		Consistently(func() bool {
+			current := &libsveltosv1beta1.HealthCheckReport{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: sveltosHCR.Namespace, Name: sveltosHCR.Name}, current)
+			return err == nil && (current.Status.Phase == nil ||
+				*current.Status.Phase != libsveltosv1beta1.ReportProcessed)
+		}, timeout, pollingInterval).Should(BeTrue())
 	})
 })
 

--- a/controllers/reloaderreport_collection.go
+++ b/controllers/reloaderreport_collection.go
@@ -28,11 +28,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/sveltos_upgrade"
 )
+
+//+kubebuilder:rbac:groups=config.projectsveltos.io,resources=clusterprofiles,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.projectsveltos.io,resources=profiles,verbs=get;list;watch
 
 // Periodically collects ReloaderReports from each managed cluster.
 func collectReloaderReports(c client.Client, collectionInterval int, shardKey, capiOnboardAnnotation, version string,
@@ -46,20 +50,165 @@ func collectReloaderReports(c client.Client, collectionInterval int, shardKey, c
 		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", capiOnboardAnnotation, shardKey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to get clusters")
+			time.Sleep(time.Duration(collectionInterval) * time.Second)
+			continue
 		}
 
+		// Restrict collection to clusters that have at least one ClusterProfile or Profile
+		// with Reloader=true. Clusters without a reloader profile generate no ReloaderReports.
+		clustersWithReloader, err := buildClustersWithReloader(ctx, c)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to build reloader cluster set")
+			time.Sleep(time.Duration(collectionInterval) * time.Second)
+			continue
+		}
+		var clustersToCollect []corev1.ObjectReference
 		for i := range clusterList {
-			cluster := &clusterList[i]
-			err = collectAndProcessReloaderReportsFromCluster(ctx, c, cluster, version, logger)
-			if err != nil {
-				logger.V(logs.LogInfo).Error(err,
-					fmt.Sprintf("failed to collect ReloaderReports from cluster: %s %s/%s",
-						cluster.Kind, cluster.Namespace, cluster.Name))
+			if clustersWithReloader[clusterList[i]] {
+				clustersToCollect = append(clustersToCollect, clusterList[i])
+			}
+		}
+
+		// In agentless mode all ReloaderReports live in the management cluster.
+		// A single List call covers every cluster, avoiding N per-cluster API calls.
+		if getAgentInMgmtCluster() {
+			if err := collectAndProcessAllReloaderReports(ctx, c, clustersToCollect, version, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to collect ReloaderReports")
+			}
+		} else {
+			for i := range clustersToCollect {
+				cluster := &clustersToCollect[i]
+				err = collectAndProcessReloaderReportsFromCluster(ctx, c, cluster, version, logger)
+				if err != nil {
+					logger.V(logs.LogInfo).Error(err,
+						fmt.Sprintf("failed to collect ReloaderReports from cluster: %s %s/%s",
+							cluster.Kind, cluster.Namespace, cluster.Name))
+				}
 			}
 		}
 
 		time.Sleep(time.Duration(collectionInterval) * time.Second)
 	}
+}
+
+// collectAndProcessAllReloaderReports is used in agentless mode. It fetches all
+// ReloaderReports from the management cluster in a single List call, groups them by
+// cluster, and processes only clusters that have reports — avoiding N per-cluster List calls.
+func collectAndProcessAllReloaderReports(ctx context.Context, c client.Client,
+	clusterList []corev1.ObjectReference, version string, logger logr.Logger) error {
+
+	shardClusters := buildShardClustersMap(clusterList)
+
+	rrList := &libsveltosv1beta1.ReloaderReportList{}
+	if err := c.List(ctx, rrList); err != nil {
+		return err
+	}
+
+	getLabels := func(r *libsveltosv1beta1.ReloaderReport) map[string]string { return r.Labels }
+	getNamespace := func(r *libsveltosv1beta1.ReloaderReport) string { return r.Namespace }
+	byCluster := groupReportsByCluster(rrList.Items, getLabels, getNamespace,
+		libsveltosv1beta1.ReloaderReportClusterNameLabel,
+		libsveltosv1beta1.ReloaderReportClusterTypeLabel,
+		shardClusters)
+
+	var retErr error
+	for _, cd := range byCluster {
+		clusterID := fmt.Sprintf("%s %s/%s", cd.ref.Kind, cd.ref.Namespace, cd.ref.Name)
+		l := logger.WithValues("cluster", clusterID)
+		if err := processReloaderReportsForClusterInAgentlessMode(ctx, c, &cd.ref, cd.items, version, l); err != nil {
+			retErr = err
+		}
+	}
+
+	return retErr
+}
+
+// processReloaderReportsForClusterInAgentlessMode handles all ReloaderReports for a single
+// cluster in agentless mode. It checks readiness, version compatibility, and processes each report.
+func processReloaderReportsForClusterInAgentlessMode(ctx context.Context, c client.Client,
+	ref *corev1.ObjectReference, rrs []*libsveltosv1beta1.ReloaderReport,
+	version string, logger logr.Logger) error {
+
+	clusterRef := &corev1.ObjectReference{
+		Namespace:  ref.Namespace,
+		Name:       ref.Name,
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+	}
+	skip, err := skipCollecting(ctx, c, clusterRef, logger)
+	if err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, c, version, ref.Namespace, ref.Name,
+		clusterproxy.GetClusterType(ref), true, logger) {
+
+		logger.V(logs.LogDebug).Info(compatibilityErrorMsg)
+		return errors.New(compatibilityErrorMsg)
+	}
+
+	var retErr error
+	for _, rr := range rrs {
+		if !rr.DeletionTimestamp.IsZero() {
+			// ReloaderReport controller handles cleanup of deleted reports.
+			continue
+		}
+		l := logger.WithValues("reloaderReport", rr.Name)
+		logger.V(logs.LogDebug).Info("updating in management cluster")
+		if err := updateReloaderReport(ctx, c, ref, rr, l); err != nil {
+			l.V(logs.LogInfo).Error(err, "failed to update ReloaderReport in management cluster")
+			retErr = err
+			continue
+		}
+		logger.V(logs.LogDebug).Info("delete ReloaderReport in management cluster")
+		if err := c.Delete(ctx, rr); err != nil && !apierrors.IsNotFound(err) {
+			l.V(logs.LogInfo).Error(err, "failed to delete ReloaderReport")
+			retErr = err
+		}
+	}
+
+	return retErr
+}
+
+// buildClustersWithReloader returns the set of clusters currently matched by at least one
+// ClusterProfile or Profile that has Spec.Reloader set to true. Only clusters that have
+// an active reloader profile will ever generate ReloaderReports, so this is used to skip
+// clusters where no collection is needed.
+func buildClustersWithReloader(ctx context.Context, c client.Client) (map[corev1.ObjectReference]bool, error) {
+	clusters := make(map[corev1.ObjectReference]bool)
+
+	clusterProfileList := &configv1beta1.ClusterProfileList{}
+	if err := c.List(ctx, clusterProfileList); err != nil {
+		return nil, err
+	}
+	for i := range clusterProfileList.Items {
+		cp := &clusterProfileList.Items[i]
+		if !cp.Spec.Reloader {
+			continue
+		}
+		for j := range cp.Status.MatchingClusterRefs {
+			clusters[cp.Status.MatchingClusterRefs[j]] = true
+		}
+	}
+
+	profileList := &configv1beta1.ProfileList{}
+	if err := c.List(ctx, profileList); err != nil {
+		return nil, err
+	}
+	for i := range profileList.Items {
+		p := &profileList.Items[i]
+		if !p.Spec.Reloader {
+			continue
+		}
+		for j := range p.Status.MatchingClusterRefs {
+			clusters[p.Status.MatchingClusterRefs[j]] = true
+		}
+	}
+
+	return clusters, nil
 }
 
 func skipCollecting(ctx context.Context, c client.Client, cluster *corev1.ObjectReference,
@@ -155,23 +304,23 @@ func collectAndProcessReloaderReportsFromCluster(ctx context.Context, c client.C
 		if !rr.DeletionTimestamp.IsZero() {
 			// ReloaderReports are deleted automatically by ReloaderReport controller
 			// after it processes them
-			logger.V(logs.LogDebug).Info("mark as deleted. Ignore it")
+			l.V(logs.LogDebug).Info("mark as deleted. Ignore it")
 			continue
 		} else {
-			logger.V(logs.LogDebug).Info("updating in management cluster")
+			l.V(logs.LogDebug).Info("updating in management cluster")
 			err = updateReloaderReport(ctx, c, cluster, rr, l)
 			if err != nil {
-				logger.V(logs.LogInfo).Error(err,
+				l.V(logs.LogInfo).Error(err,
 					"failed to update ReloaderReport in management cluster")
 				continue
 			}
 			if isPullMode {
 				continue
 			}
-			logger.V(logs.LogDebug).Info("delete ReloaderReport in managed cluster")
+			l.V(logs.LogDebug).Info("delete ReloaderReport in managed cluster")
 			err = clusterClient.Delete(ctx, rr)
 			if err != nil {
-				logger.V(logs.LogInfo).Error(err,
+				l.V(logs.LogInfo).Error(err,
 					"failed to deletd ReloaderReport in managed cluster")
 				continue
 			}

--- a/controllers/reloaderreport_collection_test.go
+++ b/controllers/reloaderreport_collection_test.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,11 +34,182 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
 
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/healthcheck-manager/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
 var _ = Describe("ReloaderReport Collection", func() {
+	var version string
+
+	BeforeEach(func() {
+		version = randomString()
+
+		By("Create the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controllers.ReportNamespace,
+				Name:      cmVersionName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Delete the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{}
+		Expect(testEnv.Get(context.TODO(),
+			types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+			cm)).To(Succeed())
+		Expect(testEnv.Delete(context.TODO(), cm)).To(Succeed())
+
+		Eventually(func() bool {
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+				cm)
+			return err != nil && apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+	})
+
+	It("buildClustersWithReloader returns clusters matched by profiles with Reloader=true", func() {
+		cluster1 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+		cluster2 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+		cluster3 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "SveltosCluster"}
+		cluster4 := corev1.ObjectReference{Namespace: randomString(), Name: randomString(), Kind: "Cluster"}
+
+		// ClusterProfile with Reloader=true matching cluster1 and cluster2.
+		cpWithReloader := &configv1beta1.ClusterProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+			Spec:       configv1beta1.Spec{Reloader: true},
+		}
+		// Profile with Reloader=true matching cluster3.
+		profileWithReloader := &configv1beta1.Profile{
+			ObjectMeta: metav1.ObjectMeta{Name: randomString(), Namespace: randomString()},
+			Spec:       configv1beta1.Spec{Reloader: true},
+		}
+		// ClusterProfile with Reloader=false matching cluster4 — must not appear in result.
+		cpNoReloader := &configv1beta1.ClusterProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+			Spec:       configv1beta1.Spec{Reloader: false},
+		}
+
+		initObjects := []client.Object{cpWithReloader, profileWithReloader, cpNoReloader}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
+			WithObjects(initObjects...).Build()
+
+		// Set Status.MatchingClusterRefs via update (fake client requires status subresource update).
+		cpWithReloader.Status.MatchingClusterRefs = []corev1.ObjectReference{cluster1, cluster2}
+		Expect(c.Status().Update(context.TODO(), cpWithReloader)).To(Succeed())
+
+		profileWithReloader.Status.MatchingClusterRefs = []corev1.ObjectReference{cluster3}
+		Expect(c.Status().Update(context.TODO(), profileWithReloader)).To(Succeed())
+
+		cpNoReloader.Status.MatchingClusterRefs = []corev1.ObjectReference{cluster4}
+		Expect(c.Status().Update(context.TODO(), cpNoReloader)).To(Succeed())
+
+		result, err := controllers.BuildClustersWithReloader(context.TODO(), c)
+		Expect(err).To(BeNil())
+		Expect(result).To(HaveLen(3))
+		Expect(result[cluster1]).To(BeTrue())
+		Expect(result[cluster2]).To(BeTrue())
+		Expect(result[cluster3]).To(BeTrue())
+		Expect(result).NotTo(HaveKey(cluster4))
+	})
+
+	It("collectAndProcessAllReloaderReports distinguishes CAPI and Sveltos clusters with same namespace and name", func() {
+		capiCluster := prepareCluster()
+
+		cmName := fmt.Sprintf("sa-%s-%s", strings.ToLower(string(libsveltosv1beta1.ClusterTypeCapi)), capiCluster.Name)
+		cmNamespace := capiCluster.Namespace
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cmNamespace,
+				Name:      cmName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+
+		capiClusterType := libsveltosv1beta1.ClusterTypeCapi
+		sveltosClusterType := libsveltosv1beta1.ClusterTypeSveltos
+
+		// capiRR: in the CAPI cluster's namespace with proper cluster labels.
+		// Spec.ClusterName is empty so updateReloaderReport will process it.
+		capiRR := &libsveltosv1beta1.ReloaderReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: capiCluster.Namespace,
+				Labels:    libsveltosv1beta1.GetReloaderReportLabels(capiCluster.Name, &capiClusterType),
+			},
+			Spec: libsveltosv1beta1.ReloaderReportSpec{
+				ClusterNamespace: capiCluster.Namespace,
+				ClusterType:      capiClusterType,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), capiRR)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, capiRR)).To(Succeed())
+
+		// sveltosRR: same namespace and cluster name as capiCluster but type=sveltos.
+		// It must NOT be processed since the sveltos cluster is not in clusterList.
+		sveltosRR := &libsveltosv1beta1.ReloaderReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: capiCluster.Namespace,
+				Labels:    libsveltosv1beta1.GetReloaderReportLabels(capiCluster.Name, &sveltosClusterType),
+			},
+			Spec: libsveltosv1beta1.ReloaderReportSpec{
+				ClusterNamespace: capiCluster.Namespace,
+				ClusterType:      sveltosClusterType,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), sveltosRR)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, sveltosRR)).To(Succeed())
+
+		capiClusterRef := corev1.ObjectReference{
+			Namespace:  capiCluster.Namespace,
+			Name:       capiCluster.Name,
+			Kind:       capiCluster.Kind,
+			APIVersion: capiCluster.APIVersion,
+		}
+
+		// Only the CAPI cluster is in the cluster list.
+		clusterList := []corev1.ObjectReference{capiClusterRef}
+		logger := textlogger.NewLogger(textlogger.NewConfig())
+
+		Expect(controllers.CollectAndProcessAllReloaderReports(context.TODO(), testEnv.Client,
+			clusterList, version, logger)).To(Succeed())
+
+		// capi RR must eventually be deleted (processed and removed by the agentless path).
+		Eventually(func() bool {
+			current := &libsveltosv1beta1.ReloaderReport{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: capiRR.Namespace, Name: capiRR.Name}, current)
+			return apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		// sveltos RR must consistently NOT be deleted (not processed).
+		Consistently(func() bool {
+			current := &libsveltosv1beta1.ReloaderReport{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: sveltosRR.Namespace, Name: sveltosRR.Name}, current)
+			return err == nil
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		Expect(testEnv.Delete(context.TODO(), sveltosRR)).To(Succeed())
+		Eventually(func() bool {
+			current := &libsveltosv1beta1.ReloaderReport{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: sveltosRR.Namespace, Name: sveltosRR.Name}, current)
+			return apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+	})
 
 	It("collectAndProcessReloaderReportsFromCluster collects ReloaderReports from cluster", func() {
 		cluster := prepareCluster()
@@ -131,11 +304,27 @@ func validateReloaderReports(cluster *clusterv1.Cluster, expectedReloaderInfo []
 		if err != nil {
 			return false
 		}
-		if len(reloaderReports.Items) != 1 {
-			By(fmt.Sprintf("found %d reloaderReports", len(reloaderReports.Items)))
+
+		filtered := []libsveltosv1beta1.ReloaderReport{}
+		// filter reports that match the cluster
+		for i := range reloaderReports.Items {
+			if !reloaderReports.Items[i].DeletionTimestamp.IsZero() {
+				continue
+			}
+
+			if reloaderReports.Items[i].Spec.ClusterNamespace == cluster.Namespace &&
+				reloaderReports.Items[i].Spec.ClusterName == cluster.Name &&
+				reloaderReports.Items[i].Spec.ClusterType == libsveltosv1beta1.ClusterTypeCapi {
+
+				filtered = append(filtered, reloaderReports.Items[i])
+			}
+		}
+
+		if len(filtered) != 1 {
+			By(fmt.Sprintf("found %d reloaderReports", len(filtered)))
 			return false
 		}
-		if !reflect.DeepEqual(reloaderReports.Items[0].Spec.ResourcesToReload, expectedReloaderInfo) {
+		if !reflect.DeepEqual(filtered[0].Spec.ResourcesToReload, expectedReloaderInfo) {
 			By("ReloaderInfo does not match")
 			return false
 		}

--- a/controllers/suite_utils_test.go
+++ b/controllers/suite_utils_test.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
-	"github.com/projectsveltos/healthcheck-manager/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
@@ -52,7 +51,6 @@ var (
 
 const (
 	sveltosKubeconfigPostfix = "-kubeconfig"
-	version                  = "v0.31.0"
 )
 
 func randomString() string {
@@ -232,22 +230,6 @@ func prepareCluster() *clusterv1.Cluster {
 	}
 	Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv.Client, secret)).To(Succeed())
-
-	By("Create the ConfigMap with sveltos-agent version")
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controllers.ReportNamespace,
-			Name:      "sveltos-agent-version",
-		},
-		Data: map[string]string{
-			"version": version,
-		},
-	}
-	err := testEnv.Create(context.TODO(), cm)
-	if err != nil {
-		Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
-	}
-	Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
 
 	Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
 

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -78,8 +78,10 @@ rules:
 - apiGroups:
   - config.projectsveltos.io
   resources:
+  - clusterprofiles
   - clustersummaries
   - clustersummaries/status
+  - profiles
   verbs:
   - get
   - list

--- a/test/fv/fv_suite_test.go
+++ b/test/fv/fv_suite_test.go
@@ -112,6 +112,10 @@ var _ = BeforeSuite(func() {
 	} else {
 		verifySveltosCluster()
 	}
+
+	if isAgentLessMode() {
+		Expect(setAddonControllerInAgentlessMode()).To(Succeed())
+	}
 })
 
 func verifySveltosCluster() {
@@ -210,21 +214,37 @@ func verifyCAPICluster() {
 
 func isAgentLessMode() bool {
 	By("Getting health check manager deployment")
-	classfierDepl := &appsv1.Deployment{}
+	healthcheckDeployment := &appsv1.Deployment{}
 	Expect(k8sClient.Get(context.TODO(),
 		types.NamespacedName{Namespace: deplNamespace, Name: deplName},
-		classfierDepl)).To(Succeed())
+		healthcheckDeployment)).To(Succeed())
 
-	Expect(len(classfierDepl.Spec.Template.Spec.Containers)).To(Equal(1))
+	Expect(len(healthcheckDeployment.Spec.Template.Spec.Containers)).To(Equal(1))
 
-	for i := range classfierDepl.Spec.Template.Spec.Containers[0].Args {
-		if strings.Contains(classfierDepl.Spec.Template.Spec.Containers[0].Args[i], "agent-in-mgmt-cluster=true") {
+	for i := range healthcheckDeployment.Spec.Template.Spec.Containers[0].Args {
+		if strings.Contains(healthcheckDeployment.Spec.Template.Spec.Containers[0].Args[i], "agent-in-mgmt-cluster=true") {
 			By("healthcheck-manager in agentless mode")
 			return true
 		}
 	}
 
 	return false
+}
+
+func setAddonControllerInAgentlessMode() error {
+	By("Getting addon-controller deployment")
+	addonControllerDepl := &appsv1.Deployment{}
+	Expect(k8sClient.Get(context.TODO(),
+		types.NamespacedName{Namespace: deplNamespace, Name: "addon-controller"},
+		addonControllerDepl)).To(Succeed())
+
+	for i := range addonControllerDepl.Spec.Template.Spec.Containers[0].Args {
+		if strings.Contains(addonControllerDepl.Spec.Template.Spec.Containers[0].Args[i], "agent-in-mgmt-cluster") {
+			addonControllerDepl.Spec.Template.Spec.Containers[0].Args[i] = "--agent-in-mgmt-cluster=true"
+		}
+	}
+
+	return k8sClient.Update(context.TODO(), addonControllerDepl)
 }
 
 // isCAPIInstalled returns true if CAPI is installed, false otherwise

--- a/test/fv/reloader_test.go
+++ b/test/fv/reloader_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
@@ -75,18 +76,77 @@ var _ = Describe("ReloaderReports processing", func() {
 		Expect(workloadClient).ToNot(BeNil())
 
 		nsName := namePrefix + randomString()
-		Byf("Creating namespace in the managed cluster %s", nsName)
-		ns := &corev1.Namespace{
+
+		deployment, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(deploymentToReload, nsName)))
+		Expect(err).To(BeNil())
+
+		Byf("Creating namespace for ConfigMap in management cluster")
+		configMapNs := randomString()
+		configMapNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nsName,
+				Name: configMapNs,
 			},
 		}
-		Expect(workloadClient.Create(context.TODO(), ns)).To(Succeed())
+		Expect(k8sClient.Create(context.TODO(), configMapNamespace)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(context.TODO(), configMapNamespace)).To(Succeed())
+		})
 
-		Byf("Create a deployment in namespace %s", nsName)
-		deployment, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(deploymentToReload, ns.Name)))
-		Expect(err).To(BeNil())
-		Expect(workloadClient.Create(context.TODO(), deployment)).To(BeNil())
+		Byf("Creating ConfigMap with namespace and deployment resources for managed cluster")
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: configMapNs,
+				Name:      namePrefix + randomString(),
+			},
+			Data: map[string]string{
+				"namespace.yaml": fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s`, nsName),
+				"deployment.yaml": fmt.Sprintf(deploymentToReload, nsName),
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
+
+		Byf("Creating ClusterProfile with Reloader=true and PolicyRefs referencing the ConfigMap")
+		clusterProfile := &configv1beta1.ClusterProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namePrefix + randomString(),
+			},
+			Spec: configv1beta1.Spec{
+				ClusterSelector: libsveltosv1beta1.Selector{
+					LabelSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{key: value},
+					},
+				},
+				Reloader: true,
+				PolicyRefs: []configv1beta1.PolicyRef{
+					{
+						Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+						Namespace: configMap.Namespace,
+						Name:      configMap.Name,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+		clusterSummary := verifyClusterSummary(clusterProfile,
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+
+		Byf("Verifying ClusterSummary %s resources are provisioned", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(clusterSummary.Namespace, clusterSummary.Name,
+			libsveltosv1beta1.FeatureResources)
+
+		Byf("Waiting for deployment %s/%s to be deployed in the managed cluster",
+			deployment.GetNamespace(), deployment.GetName())
+		Eventually(func() bool {
+			currentDepl := &appsv1.Deployment{}
+			return workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: deployment.GetNamespace(), Name: deployment.GetName()},
+				currentDepl) == nil
+		}, timeout, pollingInterval).Should(BeTrue())
 
 		Byf("Create a reloaderReport listing deployoment %s/%s as resource to reload",
 			deployment.GetNamespace(), deployment.GetName())
@@ -111,13 +171,23 @@ var _ = Describe("ReloaderReports processing", func() {
 			},
 		}
 		if isAgentLessMode() {
+			// Those are only set in agentless mode. With agents in the managed clusters,
+			// Sveltos ignores reloaderReports collected with those fields set
+			clusterType := libsveltosv1beta1.ClusterTypeCapi
+			if kindWorkloadCluster.GetKind() == libsveltosv1beta1.SveltosClusterKind {
+				clusterType = libsveltosv1beta1.ClusterTypeSveltos
+			}
+			reloaderReport.Spec.ClusterNamespace = kindWorkloadCluster.GetNamespace()
+			reloaderReport.Spec.ClusterName = kindWorkloadCluster.GetName()
+			reloaderReport.Spec.ClusterType = clusterType
 			Expect(k8sClient.Create(context.TODO(), reloaderReport)).To(BeNil())
 		} else {
 			Expect(workloadClient.Create(context.TODO(), reloaderReport)).To(BeNil())
 		}
 
 		if isAgentLessMode() {
-			Byf("Verifying ReloaderReport is removed from management cluster")
+			Byf("Verifying ReloaderReport %s/%s is removed from management cluster",
+				reloaderReport.Namespace, reloaderReport.Name)
 			Eventually(func() bool {
 				currentReloaderReport := &libsveltosv1beta1.ReloaderReport{}
 				err = k8sClient.Get(context.TODO(),
@@ -129,7 +199,8 @@ var _ = Describe("ReloaderReports processing", func() {
 				return false
 			}, timeout, pollingInterval).Should(BeTrue())
 		} else {
-			Byf("Verifying ReloaderReport is removed from managed cluster")
+			Byf("Verifying ReloaderReport %s/%s is removed from managed cluster",
+				reloaderReport.Namespace, reloaderReport.Name)
 			Eventually(func() bool {
 				currentReloaderReport := &libsveltosv1beta1.ReloaderReport{}
 				err = workloadClient.Get(context.TODO(),
@@ -161,8 +232,7 @@ var _ = Describe("ReloaderReports processing", func() {
 			return true
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		Byf("Deleting namespace %s", nsName)
-		Expect(workloadClient.Delete(context.TODO(), ns)).To(Succeed())
+		deleteClusterProfile(clusterProfile)
 	})
 })
 


### PR DESCRIPTION
When in agentless mode, all HealthCheckReport instances are in the management cluster. Instead of doing one query per cluster to get HealthCheckReports for a given cluster, query once all HealthCheckReports instances. Then process only the instance for managed clusters with correct cluster shard.

Collect HealthCheckReports only from clusters that match at least one ClusterHealthCheck. This avoids collecting from clusters with no HealthCheckReports.

When more than 50 clusters are present with drift detection, use workers to parallelize the work (up to 5 workers).

For ReloaderReport collection, collect only from clusters matching a profile with reloader knob set to true. This to avoid collecting from clusters with no ReloaderReports.

Likewise, for ReloaderReport, when in agentless mode, all HealthCheckReport instances are in the management cluster. Instead of doing one query per cluster to get HealthCheckReports for a given cluster, query once all HealthCheckReports instances. Then process only the instance for managed clusters with correct cluster shard.