### PR TITLE
opt: Cache managed-cluster clients via libsveltos clustercache

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,51 @@
+name: CodeQL
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+    branches:
+    - 'main'
+  schedule:
+  - cron: '21 3 * * 3'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['go']
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Set up Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version: 1.26.5
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Build
+      # Autobuild's heuristic only traced a fraction of the module (79 of 189 files per the
+      # code-scanning diagnostic). Build the whole module explicitly so CodeQL sees every package.
+      run: go build ./...
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: Build
       run: make build
     - name: FMT
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: ut
       run: make test
       env:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: fv
       run: make create-cluster fv
       env:
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: fv
       run: make create-cluster fv-sharding
       env:
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: fv
       run: make create-cluster fv-agentless
       env:
@@ -89,7 +89,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: fv
       run: make create-cluster-pullmode fv-pullmode
       env:
@@ -102,7 +102,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     - name: fv
       run: make create-cluster-infra fv-namespace
       env:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,45 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+  - cron: '30 2 * * 1'
+  push:
+    branches:
+    - 'main'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Run analysis
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        publish_results: true
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: SARIF file
+        path: results.sarif
+        retention-days: 5
+
+    - name: Upload to code-scanning
+      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      with:
+        sarif_file: results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG BUILDOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.12.0
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI](https://github.com/projectsveltos/healthcheck-manager/actions/workflows/main.yaml/badge.svg)](https://github.com/projectsveltos/healthcheck-manager/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/projectsveltos/healthcheck-manager)](https://goreportcard.com/report/github.com/projectsveltos/healthcheck-manager)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/projectsveltos/healthcheck-manager/badge)](https://scorecard.dev/viewer/?uri=github.com/projectsveltos/healthcheck-manager)
+[![CodeQL](https://github.com/projectsveltos/healthcheck-manager/actions/workflows/codeql.yaml/badge.svg)](https://github.com/projectsveltos/healthcheck-manager/actions/workflows/codeql.yaml)
 [![Release](https://img.shields.io/github/v/release/projectsveltos/healthcheck-manager)](https://github.com/projectsveltos/healthcheck-manager/releases)
 [![License](https://img.shields.io/badge/license-Apache-blue.svg)](LICENSE)
 [![Slack](https://img.shields.io/badge/join%20slack-%23projectsveltos-brighteen)](https://join.slack.com/t/projectsveltos/shared_invite/zt-1hraownbr-W8NTs6LTimxLPB8Erj8Q6Q)
@@ -23,11 +24,11 @@
 
 Please refere to sveltos [documentation](https://projectsveltos.github.io/sveltos/).
 
-## Contributing 
+## Contributing
 
 ❤️ Your contributions are always welcome! If you want to contribute, have questions, noticed any bug or want to get the latest project news, you can connect with us in the following ways:
 
-1. Open a bug/feature enhancement on github [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/projectsveltos/addon-controller/issues)
+1. Open a bug/feature enhancement on github [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/projectsveltos/healthcheck-manager/issues)
 2. Chat with us on the Slack in the #projectsveltos channel [![Slack](https://img.shields.io/badge/join%20slack-%23projectsveltos-brighteen)](https://join.slack.com/t/projectsveltos/shared_invite/zt-1hraownbr-W8NTs6LTimxLPB8Erj8Q6Q)
 3. [Contact Us](mailto:support@projectsveltos.io)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+We release security fixes for the latest minor version. We encourage all users to stay on the latest release.
+
+| Version        | Supported          |
+|----------------|--------------------|
+| latest release | :white_check_mark: |
+| older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+If you believe you have found a security vulnerability in any Sveltos repository, please report it responsibly by sending an email to:
+
+**support@projectsveltos.io**
+
+Please include as much of the following information as possible to help us understand and resolve the issue quickly:
+
+- A description of the vulnerability and its potential impact
+- The affected component(s) and version(s)
+- Step-by-step instructions to reproduce the issue
+- Any proof-of-concept or exploit code (if applicable)
+- Suggested remediation (if any)
+
+## Response Process
+
+- You will receive an acknowledgement within **2 business days**
+- We will investigate and keep you informed of our progress
+- Once the issue is confirmed, we will work on a fix and coordinate a release
+- We will publicly disclose the vulnerability after a fix is available, giving you credit unless you prefer to remain anonymous
+
+## Scope
+
+This policy covers all projects under the [projectsveltos](https://github.com/projectsveltos) GitHub organization.
+
+## Out of Scope
+
+- Vulnerabilities in dependencies (please report those to the upstream project)
+- Issues in non-production branches or unreleased code
+- Social engineering attacks
+
+## Thank You
+
+We appreciate responsible disclosure and the work of the security community in keeping Sveltos and its users safe.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--shard-key="
         - "--capi-onboard-annotation="
         - "--v=5"
-        - "--version=v1.12.0"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/healthcheck-manager:v1.12.0
+      - image: docker.io/projectsveltos/healthcheck-manager:main
         name: manager

--- a/controllers/clusterhealthcheck_deployer.go
+++ b/controllers/clusterhealthcheck_deployer.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/projectsveltos/healthcheck-manager/pkg/scope"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
@@ -395,6 +396,9 @@ func (r *ClusterHealthCheckReconciler) proceedProcessingClusterHealthCheck(ctx c
 		if result.Err != nil {
 			errorMessage := result.Err.Error()
 			clusterInfo.FailureMessage = &errorMessage
+
+			clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), result.Err)
 		}
 
 		if *deployerStatus == libsveltosv1beta1.SveltosStatusProvisioned {
@@ -602,6 +606,9 @@ func (r *ClusterHealthCheckReconciler) removeClusterHealthCheck(ctx context.Cont
 		if result.Err != nil {
 			failureMessage := result.Err.Error()
 			clusterInfo.FailureMessage = &failureMessage
+
+			clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), result.Err)
 		}
 	} else {
 		logger.V(logs.LogDebug).Info("no result is available. mark status as removing")
@@ -1213,7 +1220,7 @@ func proceedRemovingStaleHealthChecks(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
 	chc *libsveltosv1beta1.ClusterHealthCheck, currentReferenced *libsveltosset.Set, logger logr.Logger) error {
 
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+	remoteClient, err := clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
@@ -1408,11 +1415,14 @@ func deployHealthCheck(ctx context.Context, c client.Client, clusterNamespace, c
 			chc, healthCheck, logger)
 	}
 
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
-		"", "", clusterType, logger)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
-		return err
+	var remoteClient client.Client
+	if !isPullMode {
+		remoteClient, err = clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+			"", "", clusterType, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
+			return err
+		}
 	}
 
 	err = createOrUpdateHealthCheck(ctx, remoteClient, chc, healthCheck, clusterNamespace, clusterName,
@@ -1569,7 +1579,7 @@ func (r *ClusterHealthCheckReconciler) resetHealthCheckReportStatus(ctx context.
 		} else {
 			healthCheckReportName = chc.Spec.LivenessChecks[i].Name
 			healthCheckReportNamespace = getSveltosNamespace()
-			kubernetesClient, err = clusterproxy.GetKubernetesClient(ctx, r.Client, clusterRef.Namespace,
+			kubernetesClient, err = clustercache.GetManager().GetKubernetesClient(ctx, r.Client, clusterRef.Namespace,
 				clusterRef.Name, "", "", clusterType, logger)
 			if err != nil {
 				logger.V(logs.LogInfo).Error(err, "failed to get client")

--- a/controllers/healthcheckreport.go
+++ b/controllers/healthcheckreport.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/mgmtagent"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
@@ -52,7 +52,7 @@ func getHealthCheckReportClient(ctx context.Context, clusterNamespace, clusterNa
 
 	// Sveltos resources are always created using cluster-admin so that admin does not need to be
 	// given such permissions.
-	return clusterproxy.GetKubernetesClient(ctx, getManagementClusterClient(),
+	return clustercache.GetManager().GetKubernetesClient(ctx, getManagementClusterClient(),
 		clusterNamespace, clusterName, "", "", clusterType, logger)
 }
 

--- a/controllers/reloaderreport_controller.go
+++ b/controllers/reloaderreport_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/randutils"
@@ -119,9 +120,22 @@ func (r *ReloaderReportReconciler) processReloaderReport(ctx context.Context,
 			kind, namespace, name))
 	}
 
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, r.Client, reloaderReport.Spec.ClusterNamespace,
+	isPullMode, err := clusterproxy.IsClusterInPullMode(ctx, r.Client, reloaderReport.Spec.ClusterNamespace,
+		reloaderReport.Spec.ClusterName, reloaderReport.Spec.ClusterType, logger)
+	if err != nil {
+		return err
+	}
+	if isPullMode {
+		// In pull mode there is no direct connection to the managed cluster from here;
+		// Sveltos-applier triggers the rolling upgrade directly.
+		return nil
+	}
+
+	remoteClient, err := clustercache.GetManager().GetKubernetesClient(ctx, r.Client, reloaderReport.Spec.ClusterNamespace,
 		reloaderReport.Spec.ClusterName, "", "", reloaderReport.Spec.ClusterType, logger)
 	if err != nil {
+		clustercache.GetManager().InvalidateOnAuthError(reloaderReport.Spec.ClusterNamespace,
+			reloaderReport.Spec.ClusterName, reloaderReport.Spec.ClusterType, err)
 		return err
 	}
 

--- a/controllers/reloaderrreport.go
+++ b/controllers/reloaderrreport.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 )
 
 // ReloaderReports reside in the same cluster as the sveltos-agent component.
@@ -39,6 +39,6 @@ func getReloaderReportClient(ctx context.Context, clusterNamespace, clusterName 
 
 	// Sveltos resources are always created using cluster-admin so that admin does not need to be
 	// given such permissions.
-	return clusterproxy.GetKubernetesClient(ctx, getManagementClusterClient(),
+	return clustercache.GetManager().GetKubernetesClient(ctx, getManagementClusterClient(),
 		clusterNamespace, clusterName, "", "", clusterType, logger)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectsveltos/healthcheck-manager
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/TwiN/go-color v1.4.1
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v1.12.0
-	github.com/projectsveltos/libsveltos v1.12.0
+	github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087
 	github.com/prometheus/client_golang v1.23.2
 	github.com/slack-go/slack v0.27.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectsveltos/addon-controller v1.12.0 h1:CVCLmUrRytucRYNjGAIua68aR1lqd6C/pNSKfzjH8CA=
 github.com/projectsveltos/addon-controller v1.12.0/go.mod h1:ummIcdJVlM3n7hAFTNirdtbtQ/Lu19fKxsSfAuvtzHk=
-github.com/projectsveltos/libsveltos v1.12.0 h1:xQfo/AEh3vVRbfWVazpsgBoRgBG5vzm/sJmXp5YrUEg=
-github.com/projectsveltos/libsveltos v1.12.0/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087 h1:uOHm6bX9SKfeR6htJHrg5pXK6d2fKmdeRrs9dkIvnkA=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectsveltos/healthcheck-manager/hack/tools
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/a8m/envsubst v1.4.3

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,7 +23,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -40,7 +40,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/healthcheck-manager:v1.12.0
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -194,7 +194,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -211,7 +211,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/healthcheck-manager:v1.12.0
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "ignorePaths": ["**/test/**"],
+  "sveltos": {
+    "fileMatch": ["^.*\\.yaml$"]
+  }
+}

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:62900d55e4a3d818150e0bc46cd1657219ba0614960acecc0f3b805baba3c74d
+        image: docker.io/projectsveltos/sveltos-applier@sha256:c7e615f9eeb90362365902a6a38305b87f760c70b3e1a91c251acf2c12fb3c79
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/sveltos-agent.yaml
+++ b/test/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -203,7 +203,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent:v1.12.0
+        image: docker.io/projectsveltos/sveltos-agent:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
healthcheck-manager previously called clusterproxy.GetKubernetesClient directly in several places, which builds a new rest.Config, discovery client, and RESTMapper via a live discovery round-trip on every call. Switches to the shared lib/clustercache.GetManager() from libsveltos so these are cached, matching addon-controller and event-manager.

Also calls InvalidateOnAuthError wherever a deploy/undeploy result or a direct client fetch (HealthCheckReport, ReloaderReport) comes back with an error, so a cached client gets evicted as soon as the API server starts rejecting credentials (401/403) instead of only on TTL expiry or cluster deletion.