### PR TITLE
fix: Stale ClusterHealthCheck conditions/notifications, plus Discord/Slack formatting bugs

### DIFF
--- a/controllers/clusterhealthcheck_deployer.go
+++ b/controllers/clusterhealthcheck_deployer.go
@@ -95,15 +95,7 @@ func (r *ClusterHealthCheckReconciler) deployClusterHealthCheck(ctx context.Cont
 	var errorSeen error
 	allProcessed := true
 
-	// 1. Snapshot the clusters that are NOT yet provisioned at the start of this reconcile
-	nonProvisioned := map[corev1.ObjectReference]struct{}{}
-	for i := range chc.Status.ClusterConditions {
-		if chc.Status.ClusterConditions[i].ClusterInfo.Status != libsveltosv1beta1.SveltosStatusProvisioned {
-			nonProvisioned[chc.Status.ClusterConditions[i].ClusterInfo.Cluster] = struct{}{}
-		}
-	}
-
-	// 2. Process each cluster (deployment and status updates)
+	// 1. Process each cluster (deployment and status updates)
 	for i := range chc.Status.ClusterConditions {
 		c := &chc.Status.ClusterConditions[i]
 
@@ -150,7 +142,7 @@ func (r *ClusterHealthCheckReconciler) deployClusterHealthCheck(ctx context.Cont
 		}
 	}
 
-	// 3. Filter out entries with Status Removed
+	// 2. Filter out entries with Status Removed
 	n := 0
 	for i := range chc.Status.ClusterConditions {
 		if chc.Status.ClusterConditions[i].ClusterInfo.Status != libsveltosv1beta1.SveltosStatusRemoved {
@@ -160,9 +152,9 @@ func (r *ClusterHealthCheckReconciler) deployClusterHealthCheck(ctx context.Cont
 	}
 	chc.Status.ClusterConditions = chc.Status.ClusterConditions[:n]
 
-	// 4. Send notifications for clusters that transitioned to Provisioned
+	// 3. Evaluate liveness checks and send notifications for every provisioned cluster
 	var err error
-	chc.Status.ClusterConditions, err = r.sendNotificationsForNewlyProvisionedClusters(ctx, chc, nonProvisioned, logger)
+	chc.Status.ClusterConditions, err = r.evaluateAndNotifyProvisionedClusters(ctx, chc, logger)
 	if err != nil {
 		errorSeen = err
 	}
@@ -181,11 +173,16 @@ func (r *ClusterHealthCheckReconciler) deployClusterHealthCheck(ctx context.Cont
 	return nil
 }
 
-// sendNotificationsForNewlyProvisionedClusters identifies clusters that were just provisioned and triggers notifications.
+// evaluateAndNotifyProvisionedClusters re-evaluates liveness checks and delivers notifications for
+// every currently provisioned cluster. evaluateHealthChecksAndSendNotificationsForCluster only
+// resends a notification when its liveness status actually changed (or all notifications are
+// explicitly requested to be resent), so calling it on every reconcile is safe. This must run for
+// every provisioned cluster, not just ones newly transitioning to Provisioned: a cluster's liveness
+// state (backed by HealthCheckReport) can keep changing long after it was first provisioned, and
+// Status.Conditions needs to track that, not freeze at whatever it was on first provisioning.
 // Returns an error if any notification delivery fails.
-func (r *ClusterHealthCheckReconciler) sendNotificationsForNewlyProvisionedClusters(ctx context.Context,
-	chc *libsveltosv1beta1.ClusterHealthCheck, nonProvisioned map[corev1.ObjectReference]struct{},
-	logger logr.Logger) ([]libsveltosv1beta1.ClusterCondition, error) {
+func (r *ClusterHealthCheckReconciler) evaluateAndNotifyProvisionedClusters(ctx context.Context,
+	chc *libsveltosv1beta1.ClusterHealthCheck, logger logr.Logger) ([]libsveltosv1beta1.ClusterCondition, error) {
 
 	var errorSeen error
 
@@ -195,21 +192,18 @@ func (r *ClusterHealthCheckReconciler) sendNotificationsForNewlyProvisionedClust
 		if condition.ClusterInfo.Status == libsveltosv1beta1.SveltosStatusProvisioned {
 			cluster := &condition.ClusterInfo.Cluster
 
-			// Check if this cluster was in the non-provisioned list at the start of the reconcile
-			if _, ok := nonProvisioned[*cluster]; ok {
-				notSummary, conditions, err := evaluateHealthChecksAndSendNotificationsForCluster(ctx,
-					getManagementClusterClient(), cluster.Namespace, cluster.Name,
-					clusterproxy.GetClusterType(cluster), chc, logger)
+			notSummary, conditions, err := evaluateHealthChecksAndSendNotificationsForCluster(ctx,
+				getManagementClusterClient(), cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), chc, logger)
 
-				if err != nil {
-					failureMessage := fmt.Sprintf("failed to evaluate and deliver notifications: %v", err)
-					condition.ClusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioning
-					condition.ClusterInfo.FailureMessage = &failureMessage
-					errorSeen = err
-				} else {
-					condition.NotificationSummaries = notSummary
-					condition.Conditions = conditions
-				}
+			if err != nil {
+				failureMessage := fmt.Sprintf("failed to evaluate and deliver notifications: %v", err)
+				condition.ClusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioning
+				condition.ClusterInfo.FailureMessage = &failureMessage
+				errorSeen = err
+			} else {
+				condition.NotificationSummaries = notSummary
+				condition.Conditions = conditions
 			}
 		}
 	}

--- a/controllers/clusterhealthcheck_deployer_test.go
+++ b/controllers/clusterhealthcheck_deployer_test.go
@@ -85,6 +85,75 @@ var _ = Describe("ClusterHealthCheck deployer", func() {
 		Expect(conditions[0].Type).To(Equal(libsveltosv1beta1.ConditionType(controllers.GetConditionType(&livenessCheck))))
 	})
 
+	It("evaluateAndNotifyProvisionedClusters re-evaluates a cluster already Provisioned", func() {
+		// Regression test: conditions used to only be (re-)evaluated for clusters that had *just*
+		// transitioned to Provisioned in the current reconcile. A cluster that was already
+		// Provisioned before this reconcile started never got its liveness conditions refreshed
+		// again, so ClusterHealthCheck.Status.Conditions froze at whatever it was on first
+		// provisioning, no matter how the underlying HealthCheckReport/ClusterSummary changed later.
+		clusterNamespace := randomString()
+		clusterName := randomString()
+
+		// evaluateAndNotifyProvisionedClusters evaluates against the management cluster client
+		// (testEnv), not a fake client, so the HealthCheckReport must exist there. An empty
+		// ResourceStatuses means healthy (isStatusHealthy, liveness.go).
+		healthCheckReportClusterType := libsveltosv1beta1.ClusterTypeCapi
+		healthCheckName := randomString()
+		healthCheckReport := getHealthCheckReport(healthCheckName, clusterNamespace, clusterName)
+		healthCheckReport.Namespace = clusterNamespace
+		// fetchHealthCheckReports (liveness.go) matches on the full label set, not just
+		// HealthCheckNameLabel (which is all getHealthCheckReport sets by default).
+		healthCheckReport.Labels = libsveltosv1beta1.GetHealthCheckReportLabels(
+			healthCheckName, clusterName, &healthCheckReportClusterType)
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+		Expect(testEnv.Create(context.TODO(), healthCheckReport)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, healthCheckReport)).To(Succeed())
+
+		chc := &libsveltosv1beta1.ClusterHealthCheck{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+			Spec: libsveltosv1beta1.ClusterHealthCheckSpec{
+				LivenessChecks: []libsveltosv1beta1.LivenessCheck{
+					{
+						Name: randomString(),
+						Type: libsveltosv1beta1.LivenessTypeHealthCheck,
+						LivenessSourceRef: &corev1.ObjectReference{
+							Name:       healthCheckName,
+							Kind:       libsveltosv1beta1.HealthCheckKind,
+							APIVersion: libsveltosv1beta1.GroupVersion.String(),
+						},
+					},
+				},
+			},
+			Status: libsveltosv1beta1.ClusterHealthCheckStatus{
+				ClusterConditions: []libsveltosv1beta1.ClusterCondition{
+					{
+						ClusterInfo: libsveltosv1beta1.ClusterInfo{
+							Cluster: corev1.ObjectReference{
+								Kind: ClusterKind, APIVersion: clusterv1.GroupVersion.String(),
+								Namespace: clusterNamespace, Name: clusterName,
+							},
+							// Already Provisioned *before* this call: this is the case that was
+							// previously skipped.
+							Status: libsveltosv1beta1.SveltosStatusProvisioned,
+						},
+					},
+				},
+			},
+		}
+
+		clusterConditions, err := controllers.EvaluateAndNotifyProvisionedClusters(
+			&controllers.ClusterHealthCheckReconciler{}, context.TODO(), chc, logger)
+		Expect(err).To(BeNil())
+		Expect(clusterConditions).To(HaveLen(1))
+		Expect(clusterConditions[0].Conditions).ToNot(BeEmpty())
+		Expect(clusterConditions[0].Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+	})
+
 	It("processClusterHealthCheck queues job", func() {
 		clusterNamespace := randomString()
 		clusterName := randomString()

--- a/controllers/clusterhealthcheck_transformations.go
+++ b/controllers/clusterhealthcheck_transformations.go
@@ -46,9 +46,13 @@ func (r *ClusterHealthCheckReconciler) requeueClusterHealthCheckForHealthCheckRe
 	r.Mux.Lock()
 	defer r.Mux.Unlock()
 
-	// Use the HealthCheck this HealthCheckReport is about
+	// Use the HealthCheck this HealthCheckReport is about. Spec.HealthCheckName is not reliably
+	// populated (it comes from the managed cluster's HealthCheckReport as-is); the
+	// HealthCheckNameLabel is what every other correlation in this codebase relies on
+	// (see healthcheckreport_collection.go, evaluateLivenessCheckHealthCheck's use of
+	// GetHealthCheckReportLabels), so use that here too.
 	healthCheckInfo := corev1.ObjectReference{APIVersion: libsveltosv1beta1.GroupVersion.String(),
-		Kind: libsveltosv1beta1.HealthCheckKind, Name: healthCheckReport.Spec.HealthCheckName}
+		Kind: libsveltosv1beta1.HealthCheckKind, Name: healthCheckReport.Labels[libsveltosv1beta1.HealthCheckNameLabel]}
 
 	// Get all ClusterHealthChecks referencing this HealthCheck
 	requests := make([]ctrl.Request, r.getReferenceMapForEntry(&healthCheckInfo).Len())

--- a/controllers/clusterhealthcheck_transformations_test.go
+++ b/controllers/clusterhealthcheck_transformations_test.go
@@ -182,4 +182,50 @@ var _ = Describe("ClusterHealthCheckReconciler map functions", func() {
 		requests = controllers.RequeueClusterHealthCheckForCluster(reconciler, context.TODO(), cluster)
 		Expect(requests).To(HaveLen(0))
 	})
+
+	It("requeueClusterHealthCheckForHealthCheckReport resolves the HealthCheck from the label, not Spec.HealthCheckName",
+		func() {
+			// Regression test: Spec.HealthCheckName on a HealthCheckReport pulled from a managed
+			// cluster is not reliably set (every other correlation in this codebase uses the
+			// HealthCheckNameLabel instead). Using Spec.HealthCheckName here used to resolve to an
+			// empty HealthCheck reference, matching zero ClusterHealthChecks, so a HealthCheckReport
+			// change never actually queued a reconcile.
+			healthCheckName := randomString()
+			chcName := randomString()
+
+			reconciler := &controllers.ClusterHealthCheckReconciler{
+				Scheme:              scheme,
+				ClusterMap:          make(map[corev1.ObjectReference]*libsveltosset.Set),
+				CHCToClusterMap:     make(map[types.NamespacedName]*libsveltosset.Set),
+				ClusterHealthChecks: make(map[corev1.ObjectReference]libsveltosv1beta1.Selector),
+				HealthCheckMap:      make(map[corev1.ObjectReference]*libsveltosset.Set),
+				CHCToHealthCheckMap: make(map[types.NamespacedName]*libsveltosset.Set),
+				ClusterLabels:       make(map[corev1.ObjectReference]map[string]string),
+				Mux:                 sync.Mutex{},
+			}
+
+			healthCheckInfo := corev1.ObjectReference{APIVersion: libsveltosv1beta1.GroupVersion.String(),
+				Kind: libsveltosv1beta1.HealthCheckKind, Name: healthCheckName}
+			chcRef := &corev1.ObjectReference{APIVersion: libsveltosv1beta1.GroupVersion.String(),
+				Kind: libsveltosv1beta1.ClusterHealthCheckKind, Name: chcName}
+
+			healthCheckSet := &libsveltosset.Set{}
+			healthCheckSet.Insert(chcRef)
+			reconciler.HealthCheckMap[healthCheckInfo] = healthCheckSet
+
+			// As pulled from a managed cluster: Spec.HealthCheckName is empty, only the label is set.
+			healthCheckReport := &libsveltosv1beta1.HealthCheckReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: randomString(),
+					Name:      randomString(),
+					Labels: map[string]string{
+						libsveltosv1beta1.HealthCheckNameLabel: healthCheckName,
+					},
+				},
+			}
+
+			requests := controllers.RequeueClusterHealthCheckForHealthCheckReport(reconciler, context.TODO(), healthCheckReport)
+			expected := reconcile.Request{NamespacedName: types.NamespacedName{Name: chcName}}
+			Expect(requests).To(ContainElement(expected))
+		})
 })

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -17,15 +17,17 @@ limitations under the License.
 package controllers
 
 var (
-	RequeueClusterHealthCheckForCluster = (*ClusterHealthCheckReconciler).requeueClusterHealthCheckForCluster
+	RequeueClusterHealthCheckForCluster           = (*ClusterHealthCheckReconciler).requeueClusterHealthCheckForCluster
+	RequeueClusterHealthCheckForHealthCheckReport = (*ClusterHealthCheckReconciler).requeueClusterHealthCheckForHealthCheckReport
 
 	CleanMaps               = (*ClusterHealthCheckReconciler).cleanMaps
 	UpdateMaps              = (*ClusterHealthCheckReconciler).updateMaps
 	GetReferenceMapForEntry = (*ClusterHealthCheckReconciler).getReferenceMapForEntry
 	GetClusterMapForEntry   = (*ClusterHealthCheckReconciler).getClusterMapForEntry
 
-	ProcessClusterHealthCheck = (*ClusterHealthCheckReconciler).processClusterHealthCheck
-	UpdateClusterConditions   = (*ClusterHealthCheckReconciler).updateClusterConditions
+	ProcessClusterHealthCheck            = (*ClusterHealthCheckReconciler).processClusterHealthCheck
+	UpdateClusterConditions              = (*ClusterHealthCheckReconciler).updateClusterConditions
+	EvaluateAndNotifyProvisionedClusters = (*ClusterHealthCheckReconciler).evaluateAndNotifyProvisionedClusters
 )
 
 var (
@@ -80,6 +82,10 @@ var (
 var (
 	GetSlackInfo = getSlackInfo
 	GetWebexInfo = getWebexInfo
+
+	ComposeDiscordMessage  = composeDiscordMessage
+	ComposeSlackMessage    = composeSlackMessage
+	GetNotificationMessage = getNotificationMessage
 )
 
 func GetWebexRoom(info *webexInfo) string {

--- a/controllers/healthcheckreport_collection.go
+++ b/controllers/healthcheckreport_collection.go
@@ -635,6 +635,7 @@ func updateHealthCheckReport(ctx context.Context, c client.Client, cluster *core
 			currentHealthCheckReport.Spec.ClusterNamespace = cluster.Namespace
 			currentHealthCheckReport.Spec.ClusterName = cluster.Name
 			currentHealthCheckReport.Spec.ClusterType = clusterType
+			currentHealthCheckReport.Spec.HealthCheckName = healthCheckName
 			err = c.Create(ctx, currentHealthCheckReport)
 			if err == nil {
 				return currentHealthCheckReport, nil
@@ -648,6 +649,7 @@ func updateHealthCheckReport(ctx context.Context, c client.Client, cluster *core
 	currentHealthCheckReport.Spec.ClusterNamespace = cluster.Namespace
 	currentHealthCheckReport.Spec.ClusterName = cluster.Name
 	currentHealthCheckReport.Spec.ClusterType = clusterType
+	currentHealthCheckReport.Spec.HealthCheckName = healthCheckName
 	currentHealthCheckReport.Labels = libsveltosv1beta1.GetHealthCheckReportLabels(
 		healthCheckName, cluster.Name, &clusterType)
 	err = c.Update(ctx, currentHealthCheckReport)

--- a/controllers/healthcheckreport_collection_test.go
+++ b/controllers/healthcheckreport_collection_test.go
@@ -381,6 +381,10 @@ func validateHealthCheckReports(healthCheckName string, cluster *clusterv1.Clust
 			By("Spec ClusterNamespace and ClusterName not set")
 			return false
 		}
+		if currentHealthCheckReport.Spec.HealthCheckName != healthCheckName {
+			By("Spec HealthCheckName not set")
+			return false
+		}
 		v, ok := currentHealthCheckReport.Labels[libsveltosv1beta1.HealthCheckNameLabel]
 		return ok && v == healthCheckName
 	}, timeout, pollingInterval).Should(BeTrue())

--- a/controllers/notification.go
+++ b/controllers/notification.go
@@ -571,7 +571,17 @@ func composeDiscordMessage(message string, passing bool) ([]*discordgo.MessageEm
 			val += "\n" + line
 		}
 	}
-	content = append(content, &discordgo.MessageEmbedField{Name: name, Value: val})
+
+	// Discord rejects embed fields with an empty Name. When every liveness
+	// check is passing, no "Liveness check ... failing" line ever sets name,
+	// so there is nothing valid to pair val with as a field; fall back to a
+	// generic "Status" field instead of sending an invalid one.
+	switch {
+	case name != "":
+		content = append(content, &discordgo.MessageEmbedField{Name: name, Value: val})
+	case val != "":
+		content = append(content, &discordgo.MessageEmbedField{Name: "Status", Value: val})
+	}
 
 	embed := []*discordgo.MessageEmbed{{
 		Type:        discordgo.EmbedTypeRich,
@@ -689,11 +699,18 @@ func composeSlackMessage(message string, passing bool) (slack.Attachment, error)
 	// adding the remaining msg
 	markdownText := strings.Builder{}
 	fail_reg := regexp.MustCompile(failedTestRegexp)
+	resource_reg := regexp.MustCompile(resourceStatusRegexp)
 
 	for _, line := range lines[1:] {
-		if fail_reg.MatchString(line) {
+		switch {
+		case fail_reg.MatchString(line):
 			markdownText.WriteString("*" + line + "*\n")
-		} else {
+		case resource_reg.MatchString(line):
+			// Set the resource reference apart with code formatting, the
+			// same treatment k8s-cleaner gives resource names in Slack.
+			m := resource_reg.FindStringSubmatch(line)
+			fmt.Fprintf(&markdownText, "*%s* `%s` status is %s\n", m[1], m[2], m[3])
+		default:
 			markdownText.WriteString(line + "\n")
 		}
 	}

--- a/controllers/notification_constants.go
+++ b/controllers/notification_constants.go
@@ -26,4 +26,10 @@ const (
 	discordRed               = 15598624
 	discordGreen             = 8311585
 	failedTestRegexp         = `Liveness\s+check\s+["']([^\"']*)["']\s+failing\s`
+
+	// resourceStatusRegexp matches the "<Kind>: <namespace>/<name> status is
+	// <Status>" lines produced by isStatusHealthy (liveness.go), so the
+	// resource reference can be set apart visually (e.g. code-formatted in
+	// Slack) from the surrounding text.
+	resourceStatusRegexp = `^(\S+): (\S+) status is (\S+)\s*$`
 )

--- a/controllers/notification_test.go
+++ b/controllers/notification_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -175,5 +176,49 @@ var _ = Describe("Notification", func() {
 		Expect(slackInfo).ToNot(BeNil())
 		Expect(controllers.GetSlackChannelID(slackInfo)).To(Equal(slackChannelID))
 		Expect(controllers.GetSlackToken(slackInfo)).To(Equal(slackToken))
+	})
+
+	It("composeDiscordMessage never sends a field with an empty Name when all checks pass", func() {
+		message, passing := controllers.GetNotificationMessage(randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, nil, textlogger.NewLogger(textlogger.NewConfig()))
+		Expect(passing).To(BeTrue())
+
+		embed, err := controllers.ComposeDiscordMessage(message, passing)
+		Expect(err).To(BeNil())
+		Expect(embed).To(HaveLen(1))
+		for _, field := range embed[0].Fields {
+			Expect(field.Name).ToNot(BeEmpty())
+		}
+	})
+
+	It("composeDiscordMessage pairs each failing check with its own named field", func() {
+		conditions := []libsveltosv1beta1.Condition{
+			{Type: "check1", Status: corev1.ConditionFalse, Message: randomString()},
+			{Type: "check2", Status: corev1.ConditionFalse, Message: randomString()},
+		}
+		message, passing := controllers.GetNotificationMessage(randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, conditions, textlogger.NewLogger(textlogger.NewConfig()))
+		Expect(passing).To(BeFalse())
+
+		embed, err := controllers.ComposeDiscordMessage(message, passing)
+		Expect(err).To(BeNil())
+		Expect(embed).To(HaveLen(1))
+		Expect(embed[0].Fields).To(HaveLen(2))
+		for _, field := range embed[0].Fields {
+			Expect(field.Name).ToNot(BeEmpty())
+			Expect(field.Name).To(ContainSubstring("failing"))
+		}
+	})
+
+	It("composeSlackMessage code-formats the resource reference in a status line", func() {
+		message := "Cluster Capi:default/workload  \n" +
+			`Liveness check "HealthCheck:deployment-replicas" failing  ` + "\n" +
+			"Deployment: kube-system/metrics-server status is Degraded  \n" +
+			"Message: deployments have unavailable replicas  \n"
+
+		attachment, err := controllers.ComposeSlackMessage(message, false)
+		Expect(err).To(BeNil())
+		Expect(attachment.Text).To(ContainSubstring("`kube-system/metrics-server`"))
+		Expect(attachment.Text).To(ContainSubstring("*Deployment*"))
 	})
 })

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:bb4b52e71bb4670ada3048e3f119b20e0491eada29947674cc73abd35ed0c4fa
+        image: docker.io/projectsveltos/sveltos-applier@sha256:147f33b023082f8f095138a8306be2b7b8b312ba2c733c1afd5edca887655bc2
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Three separate bugs, each masking the next, all needed to be true at once for the symptom to appear (HealthCheckReport updates correctly, but `Status.Conditions` and notifications never follow):

- `Spec.HealthCheckName` on `HealthCheckReport` was never populated by either producer Every other correlation in this codebase already reads the `HealthCheckNameLabel` instead, so this field was silently always empty.
- `requeueClusterHealthCheckForHealthCheckReport` mapped a HealthCheckReport change to reconcile requests using that empty `Spec.HealthCheckName`, resolving to zero consumer ClusterHealthChecks. The watch predicate correctly says "this changed, reconcile", the mapper just handed back nothing to reconcile. Fixed to use the label, same as everywhere else.
- Even when a reconcile did fire, conditions/notifications were only re-evaluated for clusters *newly* transitioning to `Provisioned` in that pass. A cluster already `Provisioned` before the reconcile started was skipped, so `Status.Conditions` froze at whatever it was on first provisioning no matter how the HealthCheckReport changed afterward. `evaluateHealthChecksAndSendNotificationsForCluster` already only resends a notification when the liveness state actually changed, so re-running it for every provisioned cluster on every reconcile is safe.