### PR TITLE
fix: Don't treat a notification delivery failure as a deployment failure

### DIFF
--- a/controllers/clusterhealthcheck_deployer.go
+++ b/controllers/clusterhealthcheck_deployer.go
@@ -180,7 +180,8 @@ func (r *ClusterHealthCheckReconciler) deployClusterHealthCheck(ctx context.Cont
 // every provisioned cluster, not just ones newly transitioning to Provisioned: a cluster's liveness
 // state (backed by HealthCheckReport) can keep changing long after it was first provisioned, and
 // Status.Conditions needs to track that, not freeze at whatever it was on first provisioning.
-// Returns an error if any notification delivery fails.
+// Returns an error if liveness checks could not be evaluated, or if any notification failed to
+// deliver.
 func (r *ClusterHealthCheckReconciler) evaluateAndNotifyProvisionedClusters(ctx context.Context,
 	chc *libsveltosv1beta1.ClusterHealthCheck, logger logr.Logger) ([]libsveltosv1beta1.ClusterCondition, error) {
 
@@ -196,14 +197,27 @@ func (r *ClusterHealthCheckReconciler) evaluateAndNotifyProvisionedClusters(ctx 
 				getManagementClusterClient(), cluster.Namespace, cluster.Name,
 				clusterproxy.GetClusterType(cluster), chc, logger)
 
-			if err != nil {
-				failureMessage := fmt.Sprintf("failed to evaluate and deliver notifications: %v", err)
+			if conditions == nil {
+				// Liveness checks could not even be evaluated (e.g. failed to fetch the
+				// HealthCheckReport/ClusterSummary). This is a genuine "cluster health is
+				// unknown" problem, distinct from a notification failing to deliver, so
+				// demote status to get this cluster looked at again.
+				failureMessage := fmt.Sprintf("failed to evaluate liveness checks: %v", err)
 				condition.ClusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioning
 				condition.ClusterInfo.FailureMessage = &failureMessage
 				errorSeen = err
-			} else {
-				condition.NotificationSummaries = notSummary
-				condition.Conditions = conditions
+				continue
+			}
+
+			// Liveness checks were evaluated successfully: persist that regardless of whether
+			// every notification was delivered. A notification failure is not a deployment
+			// failure: leave ClusterInfo.Status/FailureMessage alone (a flaky webhook must not
+			// trigger a pointless redeploy of the HealthCheck on the next reconcile) and let
+			// NotificationSummaries carry the per-channel detail instead.
+			condition.Conditions = conditions
+			condition.NotificationSummaries = notSummary
+			if err != nil {
+				errorSeen = err
 			}
 		}
 	}

--- a/controllers/clusterhealthcheck_deployer_test.go
+++ b/controllers/clusterhealthcheck_deployer_test.go
@@ -154,6 +154,95 @@ var _ = Describe("ClusterHealthCheck deployer", func() {
 		Expect(clusterConditions[0].Conditions[0].Status).To(Equal(corev1.ConditionTrue))
 	})
 
+	It("evaluateAndNotifyProvisionedClusters does not demote status on a notification-only failure",
+		func() {
+			// Regression test: a notification failing to deliver (e.g. a bad webhook secret) is not
+			// a deployment failure. It must not overwrite ClusterInfo.Status/FailureMessage (which
+			// would make processClusterHealthCheck redeploy the HealthCheck on the next reconcile
+			// for no reason), and the liveness Conditions/NotificationSummaries that were
+			// successfully computed must still be persisted, not silently dropped.
+			clusterNamespace := randomString()
+			clusterName := randomString()
+
+			healthCheckReportClusterType := libsveltosv1beta1.ClusterTypeCapi
+			healthCheckName := randomString()
+			healthCheckReport := getHealthCheckReport(healthCheckName, clusterNamespace, clusterName)
+			healthCheckReport.Namespace = clusterNamespace
+			healthCheckReport.Labels = libsveltosv1beta1.GetHealthCheckReportLabels(
+				healthCheckName, clusterName, &healthCheckReportClusterType)
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterNamespace}}
+			Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+			Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+			Expect(testEnv.Create(context.TODO(), healthCheckReport)).To(Succeed())
+			Expect(waitForObject(context.TODO(), testEnv.Client, healthCheckReport)).To(Succeed())
+
+			chc := &libsveltosv1beta1.ClusterHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomString(),
+				},
+				Spec: libsveltosv1beta1.ClusterHealthCheckSpec{
+					LivenessChecks: []libsveltosv1beta1.LivenessCheck{
+						{
+							Name: randomString(),
+							Type: libsveltosv1beta1.LivenessTypeHealthCheck,
+							LivenessSourceRef: &corev1.ObjectReference{
+								Name:       healthCheckName,
+								Kind:       libsveltosv1beta1.HealthCheckKind,
+								APIVersion: libsveltosv1beta1.GroupVersion.String(),
+							},
+						},
+					},
+					// NotificationRef points at a Secret that does not exist: sendSlackNotification
+					// will fail to deliver, without conditions ever being nil.
+					Notifications: []libsveltosv1beta1.Notification{
+						{
+							Name: randomString(),
+							Type: libsveltosv1beta1.NotificationTypeSlack,
+							NotificationRef: &corev1.ObjectReference{
+								Kind:       "Secret",
+								APIVersion: "v1",
+								Namespace:  clusterNamespace,
+								Name:       randomString(),
+							},
+						},
+					},
+				},
+				Status: libsveltosv1beta1.ClusterHealthCheckStatus{
+					ClusterConditions: []libsveltosv1beta1.ClusterCondition{
+						{
+							ClusterInfo: libsveltosv1beta1.ClusterInfo{
+								Cluster: corev1.ObjectReference{
+									Kind: ClusterKind, APIVersion: clusterv1.GroupVersion.String(),
+									Namespace: clusterNamespace, Name: clusterName,
+								},
+								Status: libsveltosv1beta1.SveltosStatusProvisioned,
+							},
+						},
+					},
+				},
+			}
+
+			clusterConditions, err := controllers.EvaluateAndNotifyProvisionedClusters(
+				&controllers.ClusterHealthCheckReconciler{}, context.TODO(), chc, logger)
+			Expect(err).ToNot(BeNil())
+			Expect(clusterConditions).To(HaveLen(1))
+
+			// Deployment status must be untouched by a notification-only failure.
+			Expect(clusterConditions[0].ClusterInfo.Status).To(Equal(libsveltosv1beta1.SveltosStatusProvisioned))
+			Expect(clusterConditions[0].ClusterInfo.FailureMessage).To(BeNil())
+
+			// Liveness evaluation succeeded and must still be persisted.
+			Expect(clusterConditions[0].Conditions).ToNot(BeEmpty())
+			Expect(clusterConditions[0].Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+
+			// The notification failure itself must be visible per-channel.
+			Expect(clusterConditions[0].NotificationSummaries).To(HaveLen(1))
+			Expect(clusterConditions[0].NotificationSummaries[0].Status).
+				To(Equal(libsveltosv1beta1.NotificationStatusFailedToDeliver))
+			Expect(clusterConditions[0].NotificationSummaries[0].FailureMessage).ToNot(BeNil())
+		})
+
 	It("processClusterHealthCheck queues job", func() {
 		clusterNamespace := randomString()
 		clusterName := randomString()

--- a/test/fv/healthcheck_events_test.go
+++ b/test/fv/healthcheck_events_test.go
@@ -50,11 +50,11 @@ var _ = Describe("Liveness: healthCheck Notifications: events", func() {
 			Spec: libsveltosv1beta1.HealthCheckSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{
 					{
-						Group:   "apps",
-						Version: "v1",
+						Group:   groupApps,
+						Version: apiVersionV1,
 						Kind:    deploymentKind,
 						LabelFilters: []libsveltosv1beta1.LabelFilter{
-							{Key: "control-plane", Operation: libsveltosv1beta1.OperationEqual, Value: "sveltos-agent"},
+							{Key: controlPlaneLabelKey, Operation: libsveltosv1beta1.OperationEqual, Value: sveltosAgentLabelValue},
 						},
 					},
 				},

--- a/test/fv/healthcheck_notification_failure_test.go
+++ b/test/fv/healthcheck_notification_failure_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+// This test verifies that a notification failing to deliver (here: a Slack notification
+// whose NotificationRef points at a Secret that does not exist) does not get treated as a
+// deployment failure. The ClusterHealthCheck must stay Provisioned, liveness Conditions must
+// still be recorded, and the failure must be visible per-channel in NotificationSummaries.
+var _ = Describe("Liveness: healthCheck Notifications: failed delivery", func() {
+	const (
+		namePrefix = "healthcheck-notification-failure-"
+	)
+
+	It("Verifies a failed notification does not affect ClusterHealthCheck deployment status",
+		Label("FV", "PULLMODE"), func() {
+			healthCheck := &libsveltosv1beta1.HealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namePrefix + randomString(),
+				},
+				Spec: libsveltosv1beta1.HealthCheckSpec{
+					ResourceSelectors: []libsveltosv1beta1.ResourceSelector{
+						{
+							Group:   groupApps,
+							Version: apiVersionV1,
+							Kind:    deploymentKind,
+							LabelFilters: []libsveltosv1beta1.LabelFilter{
+								{Key: controlPlaneLabelKey, Operation: libsveltosv1beta1.OperationEqual, Value: sveltosAgentLabelValue},
+							},
+						},
+					},
+					EvaluateHealth: evaluateFunction,
+				},
+			}
+
+			By(fmt.Sprintf("Creating healthCheck %s", healthCheck.Name))
+			Expect(k8sClient.Create(context.TODO(), healthCheck)).To(Succeed())
+
+			lc := libsveltosv1beta1.LivenessCheck{
+				Name: randomString(),
+				Type: libsveltosv1beta1.LivenessTypeHealthCheck,
+				LivenessSourceRef: &corev1.ObjectReference{
+					Name:       healthCheck.Name,
+					APIVersion: libsveltosv1beta1.GroupVersion.String(),
+					Kind:       libsveltosv1beta1.HealthCheckKind,
+				},
+			}
+
+			// Deliberately do not create this Secret: the Slack notification must fail to
+			// deliver because of it.
+			notification := libsveltosv1beta1.Notification{
+				Name: randomString(),
+				Type: libsveltosv1beta1.NotificationTypeSlack,
+				NotificationRef: &corev1.ObjectReference{
+					Kind:       "Secret",
+					APIVersion: apiVersionV1,
+					Namespace:  "default",
+					Name:       namePrefix + randomString(),
+				},
+			}
+
+			Byf("Create a ClusterHealthCheck matching Cluster %s/%s", kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+			clusterHealthCheck := getClusterHealthCheck(namePrefix, map[string]string{key: value},
+				[]libsveltosv1beta1.LivenessCheck{lc}, []libsveltosv1beta1.Notification{notification})
+			Expect(k8sClient.Create(context.TODO(), clusterHealthCheck)).To(Succeed())
+
+			Byf("Verifying ClusterHealthCheck %s stays Provisioned with the liveness check recorded "+
+				"and the notification reported as failed to deliver", clusterHealthCheck.Name)
+			Eventually(func() bool {
+				currentClusterHealthCheck := &libsveltosv1beta1.ClusterHealthCheck{}
+				err := k8sClient.Get(context.TODO(),
+					types.NamespacedName{Name: clusterHealthCheck.Name}, currentClusterHealthCheck)
+				if err != nil {
+					return false
+				}
+
+				for i := range currentClusterHealthCheck.Status.ClusterConditions {
+					cc := &currentClusterHealthCheck.Status.ClusterConditions[i]
+					if !isClusterConditionForCluster(cc, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName()) {
+						continue
+					}
+
+					if cc.ClusterInfo.Status != libsveltosv1beta1.SveltosStatusProvisioned {
+						return false
+					}
+					if cc.ClusterInfo.FailureMessage != nil {
+						return false
+					}
+					if len(cc.Conditions) == 0 || cc.Conditions[0].Status != corev1.ConditionTrue {
+						return false
+					}
+					if len(cc.NotificationSummaries) != 1 {
+						return false
+					}
+					ns := &cc.NotificationSummaries[0]
+					return ns.Status == libsveltosv1beta1.NotificationStatusFailedToDeliver && ns.FailureMessage != nil
+				}
+				return false
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Byf("Deleting ClusterHealthCheck")
+			deleteClusterHealthCheck(clusterHealthCheck.Name)
+
+			Byf("Deleting HealthCheck")
+			Expect(k8sClient.Delete(context.TODO(), healthCheck)).To(Succeed())
+		})
+})

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -43,6 +43,10 @@ const (
 	value                   = "fv"
 	clusterProfileNameLabel = "projectsveltos.io/cluster-profile-name"
 	kyvernoName             = "kyverno"
+	groupApps               = "apps"
+	apiVersionV1            = "v1"
+	controlPlaneLabelKey    = "control-plane"
+	sveltosAgentLabelValue  = "sveltos-agent"
 )
 
 var (


### PR DESCRIPTION
When sending a notification failed, `ClusterInfo.Status` got demoted from `Provisioned` to `Provisioning`, so the next reconcile's `processClusterHealthCheck` would redeploy the HealthCheck to the managed cluster for no reason. Also the liveness `Conditions` and per-channel `NotificationSummaries` that were already computed successfully got discarded instead of saved, because the single aggregate `error` returned by `sendNotifications` (the last-failed channel's error) sent the caller down the "something is badly wrong" branch regardless of what actually failed.

`evaluateAndNotifyProvisionedClusters` now distinguishes the two failure modes by checking whether `conditions == nil`:

- `nil` means liveness checks could not even be evaluated (e.g. failed to fetch the HealthCheckReport). A genuine "cluster health is unknown" problem, so `ClusterInfo.Status`/ `FailureMessage` are still updated to get the cluster looked at again.
- non-nil means evaluation succeeded regardless of notification outcome. `Conditions` and `NotificationSummaries` are always persisted, `ClusterInfo.Status`/`FailureMessage` are left alone, and the per-channel failure (already correctly built by `sendNotifications`) is visible via `NotificationSummaries[i].FailureMessage` instead of being collapsed into a generic message. The aggregate error still propagates up so the reconcile requeues and retries delivery.